### PR TITLE
Fixed googletest MacOSX config, BaseException test

### DIFF
--- a/config-cmake/dep/googletest/googletest.cmake
+++ b/config-cmake/dep/googletest/googletest.cmake
@@ -13,8 +13,10 @@ set(gtest_main "${CMAKE_SOURCE_DIR}}/dep/googletest/build/googlemock/gtest/libgt
 set(gmock "${CMAKE_SOURCE_DIR}/dep/googletest/build/googlemock/libgmock.a")
 set(gmock_main "${CMAKE_SOURCE_DIR}/dep/googletest/build/googlemock/libgmock_main.a")
 
-# Apple
+# Required for MacOSX systems in order to build successfully with clang++
+# sets compiler flags to use the c++11 standard and libc++ as the C++ Standard Library Version
+# I don't know what -DGTEST_USE_OWN_TR1_TUPLE does
 if (APPLE)
-    add_definitions(-DGTEST_USE_OWN_TR1_TUPLE)
-    add_definitions(-D__GLIBCXX__)
+    add_definitions(-std=c++11 -stdlib=libc++ -DGTEST_USE_OWN_TR1_TUPLE)
 endif (APPLE)
+

--- a/src/shaka_scheme/system/exceptions/BaseException.hpp
+++ b/src/shaka_scheme/system/exceptions/BaseException.hpp
@@ -2,6 +2,7 @@
 #define SHAKA_SCHEME_BASEEXCEPTION_HPP
 
 #include <stdexcept>
+#include <string>
 
 namespace shaka {
 /**

--- a/tst/shaka_scheme/system/exceptions/unit-BaseException.cpp
+++ b/tst/shaka_scheme/system/exceptions/unit-BaseException.cpp
@@ -15,30 +15,6 @@ TEST(BaseExceptionUnitTest, constructor_success) {
 }
 
 /**
- * @brief Test: Expect std::logic_error when trying to construct the
- * std::string with a NULL pointer.
- */
-TEST(BaseExceptionUnitTest, constructor_null_failure) {
-  // When: an shaka::BaseException is thrown with a NULL for a std::string
-  // Then: expect a std::logic_error to occur.
-  EXPECT_THROW(
-      throw shaka::BaseException(
-          23094183428038290, std::string(NULL)), std::logic_error);
-}
-
-/**
- * @brief Test: Expect std::logic_error when trying to construct the
- * std::string with a nullptr pointer.
- */
-TEST(BaseExceptionUnitTest, constructor_nullptr_failure) {
-  // When: an shaka::BaseException is thrown with a nullptr for a std::string
-  // Then: expect a std::logic_error to occur.
-  EXPECT_THROW(
-      throw shaka::BaseException(
-          23094183428038290, std::string(nullptr)), std::logic_error);
-}
-
-/**
  * @brief Test: Verify Unicode character data can still be extracted
  * correctly.
  */


### PR DESCRIPTION
- Added flags to googletest.cmake for MacOSX clang
  to be able to build unit tests successfully for
  BaseException
- Removed test cases that incorrectly relied on
  undefined behaviour (initializing std::string
  with a null pointer)
- Added missing #include <string> to BaseException
  header