### PR TITLE
Completed migration of Environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/String.cpp
         src/shaka_scheme/system/base/Symbol.cpp
         src/shaka_scheme/system/base/DataPair.cpp
-        src/shaka_scheme/system/exceptions/MissingImplementationException.hpp)
+        src/shaka_scheme/system/exceptions/MissingImplementationException.hpp src/shaka_scheme/system/base/Environment.cpp src/shaka_scheme/system/base/Environment.hpp)
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})
 target_compile_options(${SHAKA_SCHEME_LIBRARY_NAME} PRIVATE -Wall -Wextra
         -pedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ include(ExternalProject)
 
 # CMake
 set(CMAKE_VERBOSE_MAKEFILE off)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY  ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY  ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # C++
 set(CMAKE_CXX_STANDARD 11)
@@ -25,10 +25,10 @@ set(CMAKE_CXX_STANDARD 11)
 set(SHAKA_SCHEME_MAJOR_VERSION 0)
 set(SHAKA_SCHEME_MINOR_VERSION 1)
 set(SHAKA_SCHEME_LIBRARY_NAME
-"shaka-scheme-${SHAKA_SCHEME_MAJOR_VERSION}.$\
+        "shaka-scheme-${SHAKA_SCHEME_MAJOR_VERSION}.$\
 {SHAKA_SCHEME_MINOR_VERSION}")
 set(SHAKA_SCHEME_REPL_NAME
-"shaka-scheme-repl-${SHAKA_SCHEME_MAJOR_VERSION}.$\
+        "shaka-scheme-repl-${SHAKA_SCHEME_MAJOR_VERSION}.$\
 {SHAKA_SCHEME_MINOR_VERSION}")
 
 include_directories(./src)
@@ -49,7 +49,8 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/String.cpp
         src/shaka_scheme/system/base/Symbol.cpp
         src/shaka_scheme/system/base/DataPair.cpp
-        src/shaka_scheme/system/exceptions/MissingImplementationException.hpp src/shaka_scheme/system/base/Environment.cpp src/shaka_scheme/system/base/Environment.hpp)
+        src/shaka_scheme/system/exceptions/MissingImplementationException.hpp
+        src/shaka_scheme/system/base/Environment.cpp)
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})
 target_compile_options(${SHAKA_SCHEME_LIBRARY_NAME} PRIVATE -Wall -Wextra
         -pedantic)

--- a/src/shaka_scheme/system/base/Data.hpp
+++ b/src/shaka_scheme/system/base/Data.hpp
@@ -27,6 +27,9 @@ class Environment;
 class DataPair;
 class UserStructData;
 
+class Data;
+
+using NodePtr = std::shared_ptr<Data>;
 
 /**
  * @brief The basic sum type or variant type of all possible Scheme data types.

--- a/src/shaka_scheme/system/base/Environment.cpp
+++ b/src/shaka_scheme/system/base/Environment.cpp
@@ -5,74 +5,75 @@
 #include "Environment.hpp"
 
 namespace shaka {
-    using Key = shaka::Symbol;
-    using Value = PairPtr;
+using Key = shaka::Symbol;
+using Value = NodePtr;
 
-    Environment::Environment(std::shared_ptr<IEnvironment<Key, Value>> parent) : parent(parent) {}
+Environment::Environment(std::shared_ptr<IEnvironment<Key, Value>> parent) :
+    parent(parent) {}
 
-    Environment::~Environment() {}
+Environment::~Environment() {}
 
-    std::shared_ptr<IEnvironment<Key, Value>> Environment::get_parent() {
-        return this->parent;
-    }
+std::shared_ptr<IEnvironment<Key, Value>> Environment::get_parent() {
+  return this->parent;
+}
 
-    void Environment::set_parent(std::shared_ptr<IEnvironment<Key, Value>> e) {
-        parent = e;
-    }
+void Environment::set_parent(std::shared_ptr<IEnvironment<Key, Value>> e) {
+  parent = e;
+}
 
-    void Environment::set_value(const Key &key, Value data) {
-        local[key] = data;
-    }
+void Environment::set_value(const Key& key, Value data) {
+  local[key] = data;
+}
 
-    Value Environment::get_value(const Key &key) {
+Value Environment::get_value(const Key& key) {
 
-        /* Check if the key exists in local */
-        if (local.find(key) != local.end()) {
-            return local[key];
-        }
-            /* Returns null if it does not exist and doesn't have a parent */
-        else if (this->parent == nullptr) {
-            throw std::runtime_error("Environment.get_value: key does not have an assigned value");
-            return std::make_shared<DataPair>(PairPtr{nullptr});
-        }
-            /* Look for key in the parent environment */
-        else {
-            return this->parent->get_value(key);
-        }
-    }
+  /* Check if the key exists in local */
+  if (local.find(key) != local.end()) {
+    return local[key];
+  }
+    /* Returns null if it does not exist and doesn't have a parent */
+  else if (this->parent == nullptr) {
+    throw std::runtime_error(
+        "Environment.get_value: key does not have an assigned value");
+  }
+    /* Look for key in the parent environment */
+  else {
+    return this->parent->get_value(key);
+  }
+}
 
-    bool Environment::contains(const Key &key) {
-        return local.find(key) != local.end();
-    }
+bool Environment::contains(const Key& key) {
+  return local.find(key) != local.end();
+}
 
-    bool Environment::is_defined(const Key &key) {
-        if (local.find(key) != local.end()) {
-            return true;
-        } else if (this->parent != nullptr) {
-            return this->parent->is_defined(key);
-        } else {
-            return false;
-        }
-    }
+bool Environment::is_defined(const Key& key) {
+  if (local.find(key) != local.end()) {
+    return true;
+  } else if (this->parent != nullptr) {
+    return this->parent->is_defined(key);
+  } else {
+    return false;
+  }
+}
 
-    std::vector<Key> Environment::get_keys() {
-        std::vector<Key> v;
-        v.reserve(local.size());
-        for (auto it: local) {
-            v.push_back(it.first);
-        }
-        return v;
-    }
+std::vector<Key> Environment::get_keys() {
+  std::vector<Key> v;
+  v.reserve(local.size());
+  for (auto it: local) {
+    v.push_back(it.first);
+  }
+  return v;
+}
 
-    const std::map<Key, Value> &Environment::get_bindings() const {
-        return local;
-    }
+const std::map<Key, Value>& Environment::get_bindings() const {
+  return local;
+}
 
-    bool operator==(const Environment &lhs, const Environment &rhs) {
-        return lhs.local == rhs.local && lhs.parent == rhs.parent;
-    }
+bool operator==(const Environment& lhs, const Environment& rhs) {
+  return lhs.local == rhs.local && lhs.parent == rhs.parent;
+}
 
-    bool operator!=(const Environment &lhs, const Environment &rhs) {
-        return !operator==(lhs, rhs);
-    }
+bool operator!=(const Environment& lhs, const Environment& rhs) {
+  return !operator==(lhs, rhs);
+}
 }

--- a/src/shaka_scheme/system/base/Environment.cpp
+++ b/src/shaka_scheme/system/base/Environment.cpp
@@ -2,7 +2,8 @@
 // Created by dylan on 9/18/17.
 //
 
-#include "Environment.hpp"
+#include <shaka_scheme/system/exceptions/InvalidInputException.hpp>
+#include "shaka_scheme/system/base/Environment.hpp"
 
 namespace shaka {
 using Key = shaka::Symbol;
@@ -33,8 +34,8 @@ Value Environment::get_value(const Key& key) {
   }
     /* Returns null if it does not exist and doesn't have a parent */
   else if (this->parent == nullptr) {
-    throw std::runtime_error(
-        "Environment.get_value: key does not have an assigned value");
+    throw shaka::InvalidInputException(2000,
+                                       "Environment.get_value: key does not have an assigned value");
   }
     /* Look for key in the parent environment */
   else {

--- a/src/shaka_scheme/system/base/Environment.cpp
+++ b/src/shaka_scheme/system/base/Environment.cpp
@@ -1,0 +1,78 @@
+//
+// Created by dylan on 9/18/17.
+//
+
+#include "Environment.hpp"
+
+namespace shaka {
+    using Key = shaka::Symbol;
+    using Value = PairPtr;
+
+    Environment::Environment(std::shared_ptr<IEnvironment<Key, Value>> parent) : parent(parent) {}
+
+    Environment::~Environment() {}
+
+    std::shared_ptr<IEnvironment<Key, Value>> Environment::get_parent() {
+        return this->parent;
+    }
+
+    void Environment::set_parent(std::shared_ptr<IEnvironment<Key, Value>> e) {
+        parent = e;
+    }
+
+    void Environment::set_value(const Key &key, Value data) {
+        local[key] = data;
+    }
+
+    Value Environment::get_value(const Key &key) {
+
+        /* Check if the key exists in local */
+        if (local.find(key) != local.end()) {
+            return local[key];
+        }
+            /* Returns null if it does not exist and doesn't have a parent */
+        else if (this->parent == nullptr) {
+            throw std::runtime_error("Environment.get_value: key does not have an assigned value");
+            return std::make_shared<DataPair>(PairPtr{nullptr});
+        }
+            /* Look for key in the parent environment */
+        else {
+            return this->parent->get_value(key);
+        }
+    }
+
+    bool Environment::contains(const Key &key) {
+        return local.find(key) != local.end();
+    }
+
+    bool Environment::is_defined(const Key &key) {
+        if (local.find(key) != local.end()) {
+            return true;
+        } else if (this->parent != nullptr) {
+            return this->parent->is_defined(key);
+        } else {
+            return false;
+        }
+    }
+
+    std::vector<Key> Environment::get_keys() {
+        std::vector<Key> v;
+        v.reserve(local.size());
+        for (auto it: local) {
+            v.push_back(it.first);
+        }
+        return v;
+    }
+
+    const std::map<Key, Value> &Environment::get_bindings() const {
+        return local;
+    }
+
+    bool operator==(const Environment &lhs, const Environment &rhs) {
+        return lhs.local == rhs.local && lhs.parent == rhs.parent;
+    }
+
+    bool operator!=(const Environment &lhs, const Environment &rhs) {
+        return !operator==(lhs, rhs);
+    }
+}

--- a/src/shaka_scheme/system/base/Environment.cpp
+++ b/src/shaka_scheme/system/base/Environment.cpp
@@ -2,7 +2,7 @@
 // Created by dylan on 9/18/17.
 //
 
-#include <shaka_scheme/system/exceptions/InvalidInputException.hpp>
+#include "shaka_scheme/system/exceptions/InvalidInputException.hpp"
 #include "shaka_scheme/system/base/Environment.hpp"
 
 namespace shaka {
@@ -35,7 +35,8 @@ Value Environment::get_value(const Key& key) {
     /* Returns null if it does not exist and doesn't have a parent */
   else if (this->parent == nullptr) {
     throw shaka::InvalidInputException(2000,
-                                       "Environment.get_value: key does not have an assigned value");
+                                       "Environment.get_value: key does not "
+                                           "have an assigned value");
   }
     /* Look for key in the parent environment */
   else {

--- a/src/shaka_scheme/system/base/Environment.hpp
+++ b/src/shaka_scheme/system/base/Environment.hpp
@@ -12,87 +12,87 @@
 
 namespace shaka {
 
-    class Environment : public IEnvironment<shaka::Symbol, NodePtr> {
+class Environment : public IEnvironment<shaka::Symbol, NodePtr> {
 
-    public:
-        using Key = shaka::Symbol;
-        using Value = NodePtr;
+public:
+  using Key = shaka::Symbol;
+  using Value = NodePtr;
 
-        /**
-        * @brief Constructor for Environment
-        * @param parent Pointer to Parent Environment, nullptr if top environment
-        */
-        Environment(std::shared_ptr<IEnvironment<Key, Value>> parent);
+  /**
+  * @brief Constructor for Environment
+  * @param parent Pointer to Parent Environment, nullptr if top environment
+  */
+  Environment(std::shared_ptr<IEnvironment<Key, Value>> parent);
 
-        /**
-         * @brief Destroys Environment
-         */
-        ~Environment() override;
+  /**
+   * @brief Destroys Environment
+   */
+  ~Environment() override;
 
-        /**
-         * @brief Gets pointer to the parent environment
-         * @return The pointer to the parent environment
-         */
+  /**
+   * @brief Gets pointer to the parent environment
+   * @return The pointer to the parent environment
+   */
 
-        std::shared_ptr<IEnvironment<Key, Value>> get_parent() override;
+  std::shared_ptr<IEnvironment<Key, Value>> get_parent() override;
 
-        /**
-         * @brief Sets the Parent Environment to 'e'
-         * @param e Pointer to an Environment
-         */
-        void set_parent(std::shared_ptr<IEnvironment<Key, Value>> e);
+  /**
+   * @brief Sets the Parent Environment to 'e'
+   * @param e Pointer to an Environment
+   */
+  void set_parent(std::shared_ptr<IEnvironment<Key, Value>> e);
 
-        /**
-         * @brief Sets an element in the Environment referred to by the 'key'
-         *        and sets its value to 'data'
-         * @param key They key to be used for lookup in the environment
-         * @param data The data associated with the key
-         */
-        void set_value(const Key &key, Value data) override;
+  /**
+   * @brief Sets an element in the Environment referred to by the 'key'
+   *        and sets its value to 'data'
+   * @param key They key to be used for lookup in the environment
+   * @param data The data associated with the key
+   */
+  void set_value(const Key& key, Value data) override;
 
-        /**
-         * @brief Returns a reference to the value referred to by the key. Key
-         *        must exist, otherwise, it throws a runtime error.
-         * @param key The key to lookup and return the value for.
-         * @return The value associated with the given key
-         */
-        Value get_value(const Key &key) override;
+  /**
+   * @brief Returns a reference to the value referred to by the key. Key
+   *        must exist, otherwise, it throws a runtime error.
+   * @param key The key to lookup and return the value for.
+   * @return The value associated with the given key
+   */
+  Value get_value(const Key& key) override;
 
-        /**
-         * @brief Returns whether a key has an associated value in the environment.
-         * @param key The key to lookup in the environment
-         * @return Whether this environment or its parents contain the key.
-         */
-        bool contains(const Key &key) override;
+  /**
+   * @brief Returns whether a key has an associated value in the environment.
+   * @param key The key to lookup in the environment
+   * @return Whether this environment or its parents contain the key.
+   */
+  bool contains(const Key& key) override;
 
-        /**
-         * @brief Returns whether a key definition is directly contained in
-         *        the environment.
-         * @param key The key to look for in this and parent environment.
-         * @return Whether the key is defined
-         */
-        bool is_defined(const Key &key) override;
+  /**
+   * @brief Returns whether a key definition is directly contained in
+   *        the environment.
+   * @param key The key to look for in this and parent environment.
+   * @return Whether the key is defined
+   */
+  bool is_defined(const Key& key) override;
 
-        /**
-         * @brief Returns a list of all the keys in the Environment.
-         * @return List of keys
-         */
-        std::vector<Key> get_keys() override;
+  /**
+   * @brief Returns a list of all the keys in the Environment.
+   * @return List of keys
+   */
+  std::vector<Key> get_keys() override;
 
-        /**
-         * @brief Returns all bindings in the Environment.
-         * @return Bindings for current Environment.
-         */
-        const std::map<Key, Value> &get_bindings() const;
+  /**
+   * @brief Returns all bindings in the Environment.
+   * @return Bindings for current Environment.
+   */
+  const std::map<Key, Value & get_bindings() const;
 
-        friend bool operator==(const shaka::Environment &, const shaka::Environment &);
+  friend bool operator==(const shaka::Environment&, const shaka::Environment&);
 
-        friend bool operator!=(const shaka::Environment &, const shaka::Environment &);
+  friend bool operator!=(const shaka::Environment&, const shaka::Environment&);
 
-    private:
-        std::shared_ptr<IEnvironment<Key, Value>> parent;
-        std::map<Key, Value> local;
-    };
+private:
+  std::shared_ptr<IEnvironment<Key, Value>> parent;
+  std::map<Key, Value> local;
+};
 
 } //namespace shaka
 

--- a/src/shaka_scheme/system/base/Environment.hpp
+++ b/src/shaka_scheme/system/base/Environment.hpp
@@ -7,17 +7,16 @@
 
 #include <map>
 #include "IEnvironment.hpp"
-#include "DataPair.hpp"
+#include "shaka_scheme/system/base/DataPair.hpp"
 #include "Symbol.hpp"
 
 namespace shaka {
-    using PairPtr = std::shared_ptr<DataPair>;
 
-    class Environment : public IEnvironment<shaka::Symbol, PairPtr> {
+    class Environment : public IEnvironment<shaka::Symbol, NodePtr> {
 
     public:
         using Key = shaka::Symbol;
-        using Value = PairPtr;
+        using Value = NodePtr;
 
         /**
         * @brief Constructor for Environment

--- a/src/shaka_scheme/system/base/Environment.hpp
+++ b/src/shaka_scheme/system/base/Environment.hpp
@@ -1,0 +1,101 @@
+//
+// Created by dylan on 9/18/17.
+//
+
+#ifndef SHAKA_SCHEME_ENVIRONMENT_H
+#define SHAKA_SCHEME_ENVIRONMENT_H
+
+#include <map>
+#include "IEnvironment.hpp"
+#include "DataPair.hpp"
+#include "Symbol.hpp"
+
+namespace shaka {
+    using PairPtr = std::shared_ptr<DataPair>;
+
+    class Environment : public IEnvironment<shaka::Symbol, PairPtr> {
+
+    public:
+        using Key = shaka::Symbol;
+        using Value = PairPtr;
+
+        /**
+        * @brief Constructor for Environment
+        * @param parent Pointer to Parent Environment, nullptr if top environment
+        */
+        Environment(std::shared_ptr<IEnvironment<Key, Value>> parent);
+
+        /**
+         * @brief Destroys Environment
+         */
+        ~Environment() override;
+
+        /**
+         * @brief Gets pointer to the parent environment
+         * @return The pointer to the parent environment
+         */
+
+        std::shared_ptr<IEnvironment<Key, Value>> get_parent() override;
+
+        /**
+         * @brief Sets the Parent Environment to 'e'
+         * @param e Pointer to an Environment
+         */
+        void set_parent(std::shared_ptr<IEnvironment<Key, Value>> e);
+
+        /**
+         * @brief Sets an element in the Environment referred to by the 'key'
+         *        and sets its value to 'data'
+         * @param key They key to be used for lookup in the environment
+         * @param data The data associated with the key
+         */
+        void set_value(const Key &key, Value data) override;
+
+        /**
+         * @brief Returns a reference to the value referred to by the key. Key
+         *        must exist, otherwise, it throws a runtime error.
+         * @param key The key to lookup and return the value for.
+         * @return The value associated with the given key
+         */
+        Value get_value(const Key &key) override;
+
+        /**
+         * @brief Returns whether a key has an associated value in the environment.
+         * @param key The key to lookup in the environment
+         * @return Whether this environment or its parents contain the key.
+         */
+        bool contains(const Key &key) override;
+
+        /**
+         * @brief Returns whether a key definition is directly contained in
+         *        the environment.
+         * @param key The key to look for in this and parent environment.
+         * @return Whether the key is defined
+         */
+        bool is_defined(const Key &key) override;
+
+        /**
+         * @brief Returns a list of all the keys in the Environment.
+         * @return List of keys
+         */
+        std::vector<Key> get_keys() override;
+
+        /**
+         * @brief Returns all bindings in the Environment.
+         * @return Bindings for current Environment.
+         */
+        const std::map<Key, Value> &get_bindings() const;
+
+        friend bool operator==(const shaka::Environment &, const shaka::Environment &);
+
+        friend bool operator!=(const shaka::Environment &, const shaka::Environment &);
+
+    private:
+        std::shared_ptr<IEnvironment<Key, Value>> parent;
+        std::map<Key, Value> local;
+    };
+
+} //namespace shaka
+
+
+#endif //SHAKA_SCHEME_ENVIRONMENT_H

--- a/src/shaka_scheme/system/base/Environment.hpp
+++ b/src/shaka_scheme/system/base/Environment.hpp
@@ -6,9 +6,9 @@
 #define SHAKA_SCHEME_ENVIRONMENT_H
 
 #include <map>
-#include "IEnvironment.hpp"
+#include "shaka_scheme/system/base/IEnvironment.hpp"
 #include "shaka_scheme/system/base/DataPair.hpp"
-#include "Symbol.hpp"
+#include "shaka_scheme/system/base/Symbol.hpp"
 
 namespace shaka {
 

--- a/src/shaka_scheme/system/base/Environment.hpp
+++ b/src/shaka_scheme/system/base/Environment.hpp
@@ -11,7 +11,9 @@
 #include "shaka_scheme/system/base/Symbol.hpp"
 
 namespace shaka {
-
+/**
+ * @brief Representation for a Scheme Environment
+ */
 class Environment : public IEnvironment<shaka::Symbol, NodePtr> {
 
 public:
@@ -61,7 +63,7 @@ public:
   /**
    * @brief Returns whether a key has an associated value in the environment.
    * @param key The key to lookup in the environment
-   * @return Whether this environment or its parents contain the key.
+   * @return Whether this environment contains the key.
    */
   bool contains(const Key& key) override;
 
@@ -83,7 +85,7 @@ public:
    * @brief Returns all bindings in the Environment.
    * @return Bindings for current Environment.
    */
-  const std::map<Key, Value & get_bindings() const;
+  const std::map<Key, Value>& get_bindings() const;
 
   friend bool operator==(const shaka::Environment&, const shaka::Environment&);
 

--- a/src/shaka_scheme/system/base/Environment.hpp
+++ b/src/shaka_scheme/system/base/Environment.hpp
@@ -57,6 +57,8 @@ public:
    *        must exist, otherwise, it throws a runtime error.
    * @param key The key to lookup and return the value for.
    * @return The value associated with the given key
+   * @throws InvalidInputException when the key does not exist in the
+   *         environment bindings
    */
   Value get_value(const Key& key) override;
 

--- a/src/shaka_scheme/system/base/IEnvironment.hpp
+++ b/src/shaka_scheme/system/base/IEnvironment.hpp
@@ -26,7 +26,7 @@ public:
    * @return The pointer to the parent environment.
    */
   virtual std::shared_ptr<IEnvironment<Key, Value>>
-  get_parent() throw() = 0;
+  get_parent() = 0;
 
   /**
    * @brief Returns whether a key has an associated value in the environment.

--- a/tst/shaka_scheme/system/base/CMakeLists.txt
+++ b/tst/shaka_scheme/system/base/CMakeLists.txt
@@ -1,3 +1,4 @@
 macro_shaka_scheme_test(unit-Data)
 macro_shaka_scheme_test(unit-Symbol)
 macro_shaka_scheme_test(unit-DataPair)
+macro_shaka_scheme_test(unit-Environment)

--- a/tst/shaka_scheme/system/base/unit-Environment.cpp
+++ b/tst/shaka_scheme/system/base/unit-Environment.cpp
@@ -1,0 +1,22 @@
+//
+// Created by dylan on 9/20/17.
+//
+
+#include <gmock/gmock.h>
+#include "shaka_scheme/system/base/Environment.hpp"
+
+using namespace shaka;
+
+TEST(EnvironmentUnitTest, parent_constructor) { }
+TEST(EnvironmentUnitTest, get_parent) { }
+TEST(EnvironmentUnitTest, set_parent) { }
+TEST(EnvironmentUnitTest, set_value) { }
+TEST(EnvironmentUnitTest, get_value_success) { }
+TEST(EnvironmentUnitTest, get_value_invalid_key_failure) { }
+TEST(EnvironmentUnitTest, contains) { }
+TEST(EnvironmentUnitTest, is_defined) { }
+TEST(EnvironmentUnitTest, get_keys) { }
+TEST(EnvironmentUnitTest, get_bindings) { }
+
+
+

--- a/tst/shaka_scheme/system/base/unit-Environment.cpp
+++ b/tst/shaka_scheme/system/base/unit-Environment.cpp
@@ -8,6 +8,9 @@
 
 using namespace shaka;
 
+/**
+ * @brief Test: Constructor with null pointer and parent pointer
+ */
 TEST(EnvironmentUnitTest, parent_constructor) {
   // Given: an environment with parent as null pointer.
   Environment e(nullptr);
@@ -26,6 +29,9 @@ TEST(EnvironmentUnitTest, parent_constructor) {
   ASSERT_EQ(e.get_parent(), parent);
 }
 
+/**
+ * @brief Test: Parent Getter
+ */
 TEST(EnvironmentUnitTest, get_parent) {
   // Given: a pointer to a parent Environment
   //        environment with parent as null pointer.
@@ -45,6 +51,9 @@ TEST(EnvironmentUnitTest, get_parent) {
 
 }
 
+/**
+ * @brief Test: Parent Setter
+ */
 TEST(EnvironmentUnitTest, set_parent) {
   // Given: a pointer to a parent Environment.
   //        a child Environment with parent initialized to null pointer.
@@ -58,6 +67,9 @@ TEST(EnvironmentUnitTest, set_parent) {
   ASSERT_EQ(child.get_parent(), parent);
 }
 
+/**
+ * @brief Test: Value Setter
+ */
 TEST(EnvironmentUnitTest, set_value) {
   // Given: an environment with parent initialized to the null pointer.
   //        a Symbol
@@ -72,6 +84,10 @@ TEST(EnvironmentUnitTest, set_value) {
   // Then: the key will have the correct value
   ASSERT_EQ(e.get_value(key), value);
 }
+
+/**
+ * @brief Test: Value Getter with Success
+ */
 TEST(EnvironmentUnitTest, get_value_success) {
   // Given: an environment, key and value
   Environment e(nullptr);
@@ -97,6 +113,10 @@ TEST(EnvironmentUnitTest, get_value_success) {
   // Then: the correct value will be returned
   ASSERT_EQ(e.get_value(key2), value2);
 }
+
+/**
+ * @brief Test: Value Getter with Failure
+ */
 TEST(EnvironmentUnitTest, get_value_invalid_key_failure) {
   // Given: an environment and key
   Environment e(nullptr);
@@ -108,6 +128,9 @@ TEST(EnvironmentUnitTest, get_value_invalid_key_failure) {
 
 }
 
+/**
+ * @brief Test: Environment contains Symbol
+ */
 TEST(EnvironmentUnitTest, contains) {
   // Given: an environment and different symbols and values
   Environment e(nullptr);
@@ -127,6 +150,9 @@ TEST(EnvironmentUnitTest, contains) {
   ASSERT_FALSE(e.contains(key2));
 }
 
+/**
+ * @brief Test: Symbol defined in Environment or Parent Environment
+ */
 TEST(EnvironmentUnitTest, is_defined) {
   // Given: a child environment, parent environment, different symbols and
   //        values
@@ -156,6 +182,10 @@ TEST(EnvironmentUnitTest, is_defined) {
   // Then: the key will not be found
   ASSERT_FALSE(parent->is_defined(child_key));
 }
+
+/**
+ * @brief Test: Environment keys getter
+ */
 TEST(EnvironmentUnitTest, get_keys) {
   // Given: an environment with defined symbols and values
   Environment e(nullptr);
@@ -177,6 +207,9 @@ TEST(EnvironmentUnitTest, get_keys) {
   ASSERT_EQ(static_cast<std::size_t>(2), e.get_keys().size());
 }
 
+/**
+ * @brief Test: Environment bindings getter
+ */
 TEST(EnvironmentUnitTest, get_bindings) {
   // Given: an environment with a symbol/data binding
   Environment e(nullptr);

--- a/tst/shaka_scheme/system/base/unit-Environment.cpp
+++ b/tst/shaka_scheme/system/base/unit-Environment.cpp
@@ -4,19 +4,182 @@
 
 #include <gmock/gmock.h>
 #include "shaka_scheme/system/base/Environment.hpp"
+#include "shaka_scheme/system/base/Data.hpp"
 
 using namespace shaka;
 
-TEST(EnvironmentUnitTest, parent_constructor) { }
-TEST(EnvironmentUnitTest, get_parent) { }
-TEST(EnvironmentUnitTest, set_parent) { }
-TEST(EnvironmentUnitTest, set_value) { }
-TEST(EnvironmentUnitTest, get_value_success) { }
-TEST(EnvironmentUnitTest, get_value_invalid_key_failure) { }
-TEST(EnvironmentUnitTest, contains) { }
-TEST(EnvironmentUnitTest, is_defined) { }
-TEST(EnvironmentUnitTest, get_keys) { }
-TEST(EnvironmentUnitTest, get_bindings) { }
+TEST(EnvironmentUnitTest, parent_constructor) {
+  // Given: an environment with parent as null pointer.
+  Environment e(nullptr);
+
+  // When: you try to get the parent
+  // Then: it will return a null pointer.
+  ASSERT_EQ(e.get_parent(), nullptr);
+
+  // Given: a pointer to a parent Environment
+  //        an Environment with parent as pointer to parent Environment.
+  auto parent = std::make_shared<Environment>(nullptr);
+  e.set_parent(parent);
+
+  // When: you try to get the parent.
+  // Then: it will return the pointer to the parent Environment.
+  ASSERT_EQ(e.get_parent(), parent);
+}
+
+TEST(EnvironmentUnitTest, get_parent) {
+  // Given: a pointer to a parent Environment
+  //        environment with parent as null pointer.
+  Environment e(nullptr);
+  auto parent = std::make_shared<Environment>(nullptr);
+
+  // When: you try to get the parent
+  // Then: it will return the pointer to the null pointer.
+  ASSERT_EQ(e.get_parent(), nullptr);
+
+  // Given: environment with parent set to pointer to parent Environment.
+  e.set_parent(parent);
+
+  // When: you try to get the parent
+  // Then: it will return the pointer to the parent Environment.
+  ASSERT_EQ(e.get_parent(), parent);
+
+}
+
+TEST(EnvironmentUnitTest, set_parent) {
+  // Given: a pointer to a parent Environment.
+  //        a child Environment with parent initialized to null pointer.
+  auto parent = std::make_shared<Environment>(nullptr);
+  Environment child(nullptr);
+
+  // When: you set the child's parent to the parent pointer.
+  child.set_parent(parent);
+
+  // Then: the child's parent will be changed to the parent pointer.
+  ASSERT_EQ(child.get_parent(), parent);
+}
+
+TEST(EnvironmentUnitTest, set_value) {
+  // Given: an environment with parent initialized to the null pointer.
+  //        a Symbol
+  //        a Value
+  Environment e(nullptr);
+  Symbol key("x");
+  auto value = create_node(String("test"));
+
+  // When: you set the key to the specified value
+  e.set_value(key, value);
+
+  // Then: the key will have the correct value
+  ASSERT_EQ(e.get_value(key), value);
+}
+TEST(EnvironmentUnitTest, get_value_success) {
+  // Given: an environment, key and value
+  Environment e(nullptr);
+  Symbol key1("x");
+  auto value1 = create_node(String("test"));
+
+  // When: you set the key to the specified value
+  e.set_value(key1, value1);
+
+  // Then: the correct value will be set
+  ASSERT_EQ(e.get_value(key1), value1);
+
+  // Given: an environment with parent set to pointer to parent environment,
+  //        key and value
+  auto parent = std::make_shared<Environment>(nullptr);
+  e.set_parent(parent);
+  Symbol key2("y");
+  auto value2 = create_node(String("parent test"));
+
+  // When: you set the key to the specified value in only the parent
+  parent->set_value(key2, value2);
+
+  // Then: the correct value will be returned
+  ASSERT_EQ(e.get_value(key2), value2);
+}
+TEST(EnvironmentUnitTest, get_value_invalid_key_failure) {
+  // Given: an environment and key
+  Environment e(nullptr);
+  Symbol key("x");
+
+  // When: you try to get a key with no binding in the environment
+  // Then: an InvalidInputException is thrown
+  ASSERT_THROW(e.get_value(key), InvalidInputException);
+
+}
+
+TEST(EnvironmentUnitTest, contains) {
+
+}
+
+TEST(EnvironmentUnitTest, is_defined) {
+  // Given: a child environment, parent environment, different symbols and
+  //        values
+  Environment child(nullptr);
+  auto parent = std::make_shared<Environment>(nullptr);
+
+  Symbol child_key("x");
+  Symbol parent_key("y");
+  auto x_value = create_node(String("x test"));
+  auto y_value = create_node(String("y test"));
+
+  // When: you define some key to be a specific value in the current environment
+  child.set_value(child_key, x_value);
+
+  // Then: the correct key will be found
+  ASSERT_TRUE(child.is_defined(child_key));
+
+  // When: you define some other key to be a different value in the parent
+  //       environment and the parent to be the child's parent
+  parent->set_value(parent_key, y_value);
+  child.set_parent(parent);
+
+  // Then: the correct key will be found
+  ASSERT_TRUE(child.is_defined(parent_key));
+
+  // When: a key is not defined in an environment
+  // Then: the key will not be found
+  ASSERT_FALSE(parent->is_defined(child_key));
+}
+TEST(EnvironmentUnitTest, get_keys) {
+  // Given: an environment with defined symbols and values
+  Environment e(nullptr);
+  Symbol key1("x");
+  Symbol key2("y");
+  auto value1 = create_node(String("test"));
+  auto value2 = create_node(String("test 2"));
+  e.set_value(key1, value1);
+  e.set_value(key2, value2);
+
+  // When: you get the keys from the environment
+  std::vector<Symbol> local_keys = e.get_keys();
+  Symbol first_key = local_keys.at(0);
+  Symbol second_key = local_keys.at(1);
+
+  // Then: the correct keys will be returned
+  ASSERT_EQ(key1, first_key);
+  ASSERT_EQ(key2, second_key);
+  ASSERT_EQ(static_cast<std::size_t>(2), e.get_keys().size());
+}
+
+TEST(EnvironmentUnitTest, get_bindings) {
+  // Given: an environment with a symbol/data binding
+  Environment e(nullptr);
+  Symbol key1("x");
+  Symbol key2("y");
+  auto value1 = create_node(String("x test"));
+  auto value2 = create_node(String("y test"));
+  e.set_value(key1, value1);
+  e.set_value(key2, value2);
+
+  // When: you get the current environment bindings
+  std::map<Symbol, NodePtr> local_bindings = e.get_bindings();
+
+  // Then: the correct bindings will be returned
+  ASSERT_EQ(local_bindings.at(key1), value1);
+  ASSERT_EQ(local_bindings.at(key2), value2);
+  ASSERT_EQ(static_cast<std::size_t >(2), e.get_bindings().size());
+}
 
 
 

--- a/tst/shaka_scheme/system/base/unit-Environment.cpp
+++ b/tst/shaka_scheme/system/base/unit-Environment.cpp
@@ -109,7 +109,22 @@ TEST(EnvironmentUnitTest, get_value_invalid_key_failure) {
 }
 
 TEST(EnvironmentUnitTest, contains) {
+  // Given: an environment and different symbols and values
+  Environment e(nullptr);
+  Symbol key1("x");
+  Symbol key2("y");
+  auto x_value = create_node(String("x test"));
 
+  // When: you define some key to be a specific value in the current
+  //       environment
+  e.set_value(key1, x_value);
+
+  // Then: the correct value will be found in the current environment
+  ASSERT_TRUE(e.contains(key1));
+
+  // When: a key is not contained in the current environment
+  // Then: the key will not be found
+  ASSERT_FALSE(e.contains(key2));
 }
 
 TEST(EnvironmentUnitTest, is_defined) {


### PR DESCRIPTION
I finished migrating the Environment code from the old-version-Spring-2017 branch.
- Function definitions are contained in the source file
- Only function declarations are in the header file

I discussed with Austin regarding `contains()` in Environment, and we decided that it will only check for the key in the current Environment, while `is_defined()` will recursively check the current Environment and all parents.

I also added the unit-tests for Environment and updated documentation.

**I think everything should be correct. Please let me know if you notice anything wrong with my implementation.**