### PR TITLE
Pull Request for HeapVirtualMachine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/DataPair.cpp
         src/shaka_scheme/system/exceptions/MissingImplementationException.hpp
         src/shaka_scheme/system/base/Environment.cpp
-        src/shaka_scheme/system/vm/CallFrame.cpp)
+        src/shaka_scheme/system/vm/CallFrame.cpp
+        src/shaka_scheme/system/vm/HeapVirtualMachine.cpp)
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})
 target_compile_options(${SHAKA_SCHEME_LIBRARY_NAME} PRIVATE -Wall -Wextra
         -pedantic)

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -1,0 +1,61 @@
+//
+// Created by Billy Wooton on 10/2/17.
+//
+
+#include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
+
+namespace shaka {
+
+NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
+  shaka::DataPair& exp_pair = exp->get<DataPair>();
+  shaka::Symbol& instruction = exp_pair.car()->get<Symbol>();
+
+  if (instruction == shaka::Symbol("halt")) {
+    return this->acc;
+  }
+
+}
+
+Accumulator HeapVirtualMachine::get_accumulator() const {
+  return this->acc;
+}
+
+Expression HeapVirtualMachine::get_expression() const {
+  return this->exp;
+}
+
+EnvPtr HeapVirtualMachine::get_environment() const {
+  return this->env;
+}
+
+ValueRib HeapVirtualMachine::get_value_rib() const {
+  return this->rib;
+}
+
+FramePtr HeapVirtualMachine::get_call_frame() const {
+  return this->frame;
+}
+
+void HeapVirtualMachine::set_accumulator(Accumulator a) {
+  this->acc = a;
+}
+
+void HeapVirtualMachine::set_expression(Expression x) {
+  this->exp = x;
+}
+
+void HeapVirtualMachine::push_call_frame(FramePtr s) {
+  this->frame = s;
+}
+
+void HeapVirtualMachine::set_environment(EnvPtr e) {
+  this->env = e;
+}
+
+void HeapVirtualMachine::set_value_rib(ValueRib r) {
+  this->rib = r;
+}
+
+
+} //namespace shaka
+

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -10,13 +10,13 @@ namespace shaka {
 
 HeapVirtualMachine::~HeapVirtualMachine() {}
 
-NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
+void HeapVirtualMachine::evaluate_assembly_instruction() {
   shaka::DataPair& exp_pair = exp->get<DataPair>();
   shaka::Symbol& instruction = exp_pair.car()->get<Symbol>();
 
   // (halt)
   if (instruction == shaka::Symbol("halt")) {
-    return this->acc;
+    return;
   }
 
   // (refer var x)
@@ -29,8 +29,6 @@ NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
     NodePtr next_expression = next_pair.car();
 
     this->set_expression(next_expression);
-
-    return nullptr;
   }
 
   // (constant obj x)
@@ -63,7 +61,6 @@ NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
       this->set_expression(then_exp);
     }
 
-    return nullptr;
   }
 
   // (assign var x)
@@ -80,7 +77,6 @@ NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
 
     this->set_expression(expression);
 
-    return nullptr;
   }
 
   // (frame x ret)
@@ -102,7 +98,6 @@ NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
 
     this->set_value_rib(vr);
 
-    return nullptr;
   }
 
   // (argument x)
@@ -116,7 +111,6 @@ NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
 
     this->set_expression(x);
 
-    return nullptr;
   }
 
   // (return)
@@ -127,10 +121,8 @@ NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
     this->set_environment(this->frame->get_environment_pointer());
     this->frame = this->frame->get_next_frame();
 
-    return nullptr;
   }
 
-  return nullptr;
 }
 
 Accumulator HeapVirtualMachine::get_accumulator() const {

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -3,8 +3,11 @@
 //
 
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
+#include "shaka_scheme/system/base/Environment.hpp"
 
 namespace shaka {
+
+HeapVirtualMachine::~HeapVirtualMachine() {}
 
 NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
   shaka::DataPair& exp_pair = exp->get<DataPair>();
@@ -14,6 +17,19 @@ NodePtr HeapVirtualMachine::evaluate_assembly_instruction() {
     return this->acc;
   }
 
+  if (instruction == shaka::Symbol("refer")) {
+    shaka::DataPair& exp_cdr = exp_pair.cdr()->get<DataPair>();
+    shaka::Symbol& var = exp_cdr.car()->get<Symbol>();
+    this->set_accumulator(env->get_value(var));
+
+    NodePtr next_expression = exp_cdr.cdr();
+
+    this->set_expression(next_expression);
+
+    return nullptr;
+  }
+
+  return nullptr;
 }
 
 Accumulator HeapVirtualMachine::get_accumulator() const {

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
@@ -1,0 +1,127 @@
+//
+// Created by Billy Wooton on 9/8/17.
+//
+
+#ifndef SHAKA_SCHEME_HEAPVIRTUALMACHINE_HPP
+#define SHAKA_SCHEME_HEAPVIRTUALMACHINE_HPP
+
+
+#include <vector>
+#include "shaka_scheme/system/base/Data.hpp"
+
+namespace shaka {
+
+
+/**
+ * @note Forward declaration of CallFrame class that will need to
+ * be implemented to augment the design of the VM
+ */
+
+class CallFrame;
+
+/**
+ * @note These are type aliases to assist in maintaining uniformity
+ * of VM design in preparation for later design changes to other parts
+ * of the system. These aliases can be changed later without the
+ * entire code base for the VM needing to be modified
+ */
+
+using Accumulator = NodePtr;
+using Expression = NodePtr;
+using EnvPtr = std::shared_ptr<Environment>;
+using ValueRib = std::vector<NodePtr>;
+using FramePtr = std::shared_ptr<CallFrame>;
+
+
+/**
+ * @brief The class implementation for the Virtual Machine.
+ * Lays out the specification of the Heap Based Virtual Machine
+ * Based on R. Kent Dybvig's PhD dissertation
+ */
+class HeapVirtualMachine {
+
+  HeapVirtualMachine(
+      Accumulator a,
+      Expression x,
+      EnvPtr e,
+      ValueRib r,
+      FramePtr s) : a(a), x(x), e(e), r(r), s(s) {}
+
+   ~HeapVirtualMachine();
+
+  /**
+    * @brief The method that actually processes the 12 assembly instructions
+    * Changes the contents of each register in place
+    */
+  void evaluate_assembly_instruction();
+
+  /**
+  * @brief Returns the current contents of the Accumulator register
+  * @return The contents of the Accumulator
+  */
+  Accumulator get_accumulator() const;
+
+  /**
+   * @brief Returns the contents of the Expression register
+   * @return The next expression to be evaluated
+   */
+  Expression get_expression() const;
+
+  /**
+   * @brief Returns the contents of the Environment register
+   * @return The EnvPtr which points to the immediate Environment frame
+   */
+  EnvPtr get_environment() const;
+
+  /**
+   * @brief Returns the contents of the ValueRib register
+   * @return The std::vector of arguments (NodePtr) evaluated thus far
+   */
+  ValueRib get_value_rib() const;
+
+  /**
+   * @brief Returns the contents of the CurrentStack register
+   * @return The pointer to the top CallFrame on the stack
+   */
+  FramePtr get_call_frame() const;
+
+  /**
+   * @brief Sets the value of the Accumulator register
+   * @param a The new value to be placed in the Accumulator
+   */
+  void set_accumulator(Accumulator a);
+
+  /**
+   * @brief Sets the value of the Expression register
+   * @param x The new contents of the Expression register
+   */
+  void set_expression(Expression x);
+
+  /**
+   * @brief Restores parameter s to be the CurrentStack
+   * @param s The pointer to a CallFrame to represent the new CurrentStack
+   */
+  void push_call_frame(FramePtr s);
+
+  /**
+   * @brief Sets the value of the Environment register to be the parameter e
+   * @param e The new contents of the Environment register
+   */
+  void set_environment(EnvPtr e);
+
+  /**
+   * @brief Sets the ValueRib register to be the parameter r
+   * @param r The new contents of the ValueRib register
+   */
+  void set_value_rib(ValueRib r);
+
+private:
+  Accumulator a;
+  Expression x;
+  EnvPtr e;
+  ValueRib r;
+  FramePtr s;
+};
+
+}// namespace shaka
+#endif //SHAKA_SCHEME_HEAPVIRTUALMACHINE_HPP

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
@@ -45,7 +45,7 @@ class HeapVirtualMachine {
       Expression x,
       EnvPtr e,
       ValueRib r,
-      FramePtr s) : a(a), x(x), e(e), r(r), s(s) {}
+      FramePtr s) : acc(a), exp(x), env(e), rib(r), frame(s) {}
 
    ~HeapVirtualMachine();
 
@@ -53,7 +53,7 @@ class HeapVirtualMachine {
     * @brief The method that actually processes the 12 assembly instructions
     * Changes the contents of each register in place
     */
-  void evaluate_assembly_instruction();
+  NodePtr evaluate_assembly_instruction();
 
   /**
   * @brief Returns the current contents of the Accumulator register
@@ -116,11 +116,11 @@ class HeapVirtualMachine {
   void set_value_rib(ValueRib r);
 
 private:
-  Accumulator a;
-  Expression x;
-  EnvPtr e;
-  ValueRib r;
-  FramePtr s;
+  Accumulator acc;
+  Expression exp;
+  EnvPtr env;
+  ValueRib rib;
+  FramePtr frame;
 };
 
 }// namespace shaka

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
@@ -40,6 +40,8 @@ using FramePtr = std::shared_ptr<CallFrame>;
  */
 class HeapVirtualMachine {
 
+public:
+
   HeapVirtualMachine(
       Accumulator a,
       Expression x,

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
@@ -55,7 +55,7 @@ public:
     * @brief The method that actually processes the 12 assembly instructions
     * Changes the contents of each register in place
     */
-  NodePtr evaluate_assembly_instruction();
+  void evaluate_assembly_instruction();
 
   /**
   * @brief Returns the current contents of the Accumulator register

--- a/tst/shaka_scheme/system/CMakeLists.txt
+++ b/tst/shaka_scheme/system/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(base)
 add_subdirectory(exceptions)
 add_subdirectory(core)
+add_subdirectory(vm)
+

--- a/tst/shaka_scheme/system/vm/CMakeLists.txt
+++ b/tst/shaka_scheme/system/vm/CMakeLists.txt
@@ -1,0 +1,1 @@
+macro_shaka_scheme_test(unit-HeapVirtualMachine)

--- a/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
+++ b/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
@@ -6,6 +6,7 @@
 #include "shaka_scheme/system/base/Data.hpp"
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
 #include "shaka_scheme/system/base/Environment.hpp"
+#include "shaka_scheme/system/core/lists.hpp"
 
 using namespace shaka;
 
@@ -54,7 +55,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
   DataPair next_instr_pair(next_instr_data);
 
   Data var_data(var);
-  DataPair var_x_pair(var, next_instr_pair);
+  DataPair var_x_pair(var_data, *core::list(create_node(next_instr_pair)));
 
   Data instruction_data(instruction);
   DataPair refer_var_x(instruction_data, var_x_pair);
@@ -86,4 +87,240 @@ TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
 
   // Then: It will return the contents of the accumulator
   ASSERT_EQ(result, env->get_value(Symbol("a")));
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (constant obj x) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_constant) {
+  // Given: An assembly instruction of the form (constant "Hello" (halt))
+
+  Symbol instruction("constant");
+  String obj("Hello");
+  Symbol next_instr("halt");
+
+  Data next_instr_data(next_instr);
+  DataPair next_instr_pair(next_instr_data);
+
+  Data obj_data(obj);
+  DataPair constant_obj_pair(obj_data,
+                             *core::list(create_node(next_instr_pair)));
+
+  Data instruction_data(instruction);
+  DataPair constant_obj_x(instruction_data, constant_obj_pair);
+
+  NodePtr expression = std::make_shared<Data>(constant_obj_x);
+
+  // Given: A pointer to an empty environment frame
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: An empty ValueRib
+
+  ValueRib vr;
+
+  // Given: A HeapVirtualMachine instance constructed with these items
+
+  HeapVirtualMachine hvm(nullptr, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction method on hvm
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The accumulator will hold the string "Hello"
+  ASSERT_EQ(hvm.get_accumulator()->get<String>(), String("Hello"));
+
+  // Then: The next expression will be (halt)
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+            Symbol("halt"));
+
+  // When: You then invoke the evaluate_assembly_instruction method again
+
+  auto result = hvm.evaluate_assembly_instruction();
+
+  // Then: The result you get back is the String("Hello")
+
+  ASSERT_EQ(result->get<String>(), String("Hello"));
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (test then else) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
+
+  // Given: An Accumulator that is the symbol #f
+
+  NodePtr accumulator = std::make_shared<Data>(Symbol("#f"));
+
+  // Given: A then expression of the form (constant "then" (halt))
+  Symbol then_inst("constant");
+  Data then_inst_data(then_inst);
+
+
+  String then_obj("then");
+  Data then_obj_data(then_obj);
+
+  Symbol halt_inst("halt");
+  Data halt_data(halt_inst);
+  DataPair halt_pair(halt_data);
+
+  DataPair obj_halt_pair(then_obj_data,
+                         *core::list(create_node(halt_pair)));
+
+  DataPair const_obj_halt(then_inst_data, obj_halt_pair);
+
+  NodePtr expr = std::make_shared<Data>(const_obj_halt);
+
+  // Given: An else expression of the form (constant "else" (halt))
+
+  Symbol else_inst("constant");
+  Data else_inst_data(then_inst);
+
+  String else_obj("else");
+  Data else_obj_data(else_obj);
+
+  DataPair else_obj_halt_pair(else_obj_data,
+                              *core::list(create_node(halt_pair)));
+
+  DataPair const_else_obj_halt(else_inst_data, else_obj_halt_pair);
+
+  NodePtr expr2 = std::make_shared<Data>(const_else_obj_halt);
+
+  // Given: An assembly instruction of the form (test then else)
+
+  Symbol instruction("test");
+
+  Data instruction_data(instruction);
+
+  DataPair then_else_pair(expr, create_node(DataPair(*expr2)));
+
+  DataPair test_then_else(instruction_data, then_else_pair);
+
+  NodePtr expression = std::make_shared<Data>(test_then_else);
+
+  // Given: An EnvPtr that points to an empty environment
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: An empty ValueRib
+
+  ValueRib vr;
+
+  // Given: An instance of the HeapVirtualMachine constructed with these items
+
+  HeapVirtualMachine hvm(accumulator, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction_method
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The next expression will be (constant "else" (halt))
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().cdr()->get<DataPair>().car
+      ()->get<String>(), String("else"));
+
+  // When: You invoke the evaluate_assembly_instruction_method again
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The accumulator will hold the string "else"
+
+  ASSERT_EQ(hvm.get_accumulator()->get<String>(), String("else"));
+
+  // Then: The next expression will be (halt)
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+  Symbol("halt"));
+
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (test then else) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
+
+  // Given: An Accumulator that is the symbol #t
+
+  NodePtr accumulator = std::make_shared<Data>(Symbol("#t"));
+
+  // Given: A then expression of the form (constant "then" (halt))
+  Symbol then_inst("constant");
+  Data then_inst_data(then_inst);
+
+
+  String then_obj("then");
+  Data then_obj_data(then_obj);
+
+  Symbol halt_inst("halt");
+  Data halt_data(halt_inst);
+  DataPair halt_pair(halt_data);
+
+  DataPair obj_halt_pair(then_obj_data,
+                         *core::list(create_node(halt_pair)));
+
+  DataPair const_obj_halt(then_inst_data, obj_halt_pair);
+
+  NodePtr expr = std::make_shared<Data>(const_obj_halt);
+
+  // Given: An else expression of the form (constant "else" (halt))
+
+  Symbol else_inst("constant");
+  Data else_inst_data(then_inst);
+
+  String else_obj("else");
+  Data else_obj_data(else_obj);
+
+  DataPair else_obj_halt_pair(else_obj_data,
+                              *core::list(create_node(halt_pair)));
+
+  DataPair const_else_obj_halt(else_inst_data, else_obj_halt_pair);
+
+  NodePtr expr2 = std::make_shared<Data>(const_else_obj_halt);
+
+  // Given: An assembly instruction of the form (test then else)
+
+  Symbol instruction("test");
+
+  Data instruction_data(instruction);
+
+  DataPair then_else_pair(expr, create_node(DataPair(*expr2)));
+
+  DataPair test_then_else(instruction_data, then_else_pair);
+
+  NodePtr expression = std::make_shared<Data>(test_then_else);
+
+  // Given: An EnvPtr that points to an empty environment
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: An empty ValueRib
+
+  ValueRib vr;
+
+  // Given: An instance of the HeapVirtualMachine constructed with these items
+
+  HeapVirtualMachine hvm(accumulator, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction_method
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The next expression will be (constant "then" (halt))
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().cdr()->get<DataPair>().car
+      ()->get<String>(), String("then"));
+
+  // When: You invoke the evaluate_assembly_instruction_method again
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The accumulator will hold the string "then"
+
+  ASSERT_EQ(hvm.get_accumulator()->get<String>(), String("then"));
+
+  // Then: The next expression will be (halt)
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+            Symbol("halt"));
+
 }

--- a/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
+++ b/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
@@ -36,10 +36,10 @@ TEST(HeapVirtualMachineUnitTest, evaluate_halt) {
   HeapVirtualMachine hvm (accumulator, expression, env, vr, nullptr);
 
   // When: You invoke the evaluate_assembly_instruction() method
-  auto result = hvm.evaluate_assembly_instruction();
+  hvm.evaluate_assembly_instruction();
 
   // Then: It will return the contents of the accumulator register
-  ASSERT_EQ(result->get<Symbol>(), Symbol("result"));
+  ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("result"));
 
 }
 
@@ -84,10 +84,11 @@ TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
             Symbol("halt"));
 
   // When: You then invoke the evaluate_assembly_instruction() method again
-  auto result = hvm.evaluate_assembly_instruction();
+  hvm.evaluate_assembly_instruction();
 
   // Then: It will return the contents of the accumulator
-  ASSERT_EQ(result, env->get_value(Symbol("a")));
+  ASSERT_EQ(hvm.get_accumulator()->get<String>(),
+            env->get_value(Symbol("a"))->get<String>());
 }
 
 /**
@@ -137,11 +138,11 @@ TEST(HeapVirtualMachineUnitTest, evaluate_constant) {
 
   // When: You then invoke the evaluate_assembly_instruction method again
 
-  auto result = hvm.evaluate_assembly_instruction();
+  hvm.evaluate_assembly_instruction();
 
   // Then: The result you get back is the String("Hello")
 
-  ASSERT_EQ(result->get<String>(), String("Hello"));
+  ASSERT_EQ(hvm.get_accumulator()->get<String>(), String("Hello"));
 }
 
 /**
@@ -486,11 +487,11 @@ TEST(HeapVirtualMachineUnitTest, evaluate_frame) {
 
   // When: You invoke the evaluate_assembly_instruction() method again
 
-  auto result = hvm.evaluate_assembly_instruction();
+  hvm.evaluate_assembly_instruction();
 
   // Then: It will return the contents of the Accumulator
 
-  ASSERT_EQ(result->get<Symbol>(), Symbol("finale"));
+  ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("finale"));
 
 }
 
@@ -544,11 +545,11 @@ TEST(HeapVirtualMachineUnitTest, evaluate_argument) {
 
   // When: You invoke the evaluate_assembly_instruction() method again
 
-  auto result = hvm.evaluate_assembly_instruction();
+  hvm.evaluate_assembly_instruction();
 
   // Then: You will get back the banana that is in the Accumulator
 
-  ASSERT_EQ(result->get<Symbol>(), Symbol("banana"));
+  ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("banana"));
 
 }
 
@@ -631,10 +632,10 @@ TEST(HeapVirtualMachineUnitTest, evaluate_return) {
 
   // When: You invoke the evaluate_assembly_instruction method again
 
-  auto result = hvm.evaluate_assembly_instruction();
+  hvm.evaluate_assembly_instruction();
 
   // Then: The result you get back is the symbol 'finale
 
-  ASSERT_EQ(result->get<Symbol>(), Symbol("finale"));
+  ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("finale"));
 
 }

--- a/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
+++ b/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
@@ -38,7 +38,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_halt) {
   // When: You invoke the evaluate_assembly_instruction() method
   hvm.evaluate_assembly_instruction();
 
-  // Then: It will return the contents of the accumulator register
+  // Then: The accumulator register will contain the symbol 'result
   ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("result"));
 
 }
@@ -86,7 +86,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
   // When: You then invoke the evaluate_assembly_instruction() method again
   hvm.evaluate_assembly_instruction();
 
-  // Then: It will return the contents of the accumulator
+  // Then: The accumulator will contain the string "test"
   ASSERT_EQ(hvm.get_accumulator()->get<String>(),
             env->get_value(Symbol("a"))->get<String>());
 }
@@ -140,7 +140,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_constant) {
 
   hvm.evaluate_assembly_instruction();
 
-  // Then: The result you get back is the String("Hello")
+  // Then: The accumulator register will contain the string "Hello"
 
   ASSERT_EQ(hvm.get_accumulator()->get<String>(), String("Hello"));
 }
@@ -489,7 +489,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_frame) {
 
   hvm.evaluate_assembly_instruction();
 
-  // Then: It will return the contents of the Accumulator
+  // Then: The accumulator will hold the symbol 'finale
 
   ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("finale"));
 
@@ -547,7 +547,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_argument) {
 
   hvm.evaluate_assembly_instruction();
 
-  // Then: You will get back the banana that is in the Accumulator
+  // Then: The accumulator register will hold the symbol 'banana
 
   ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("banana"));
 
@@ -634,7 +634,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_return) {
 
   hvm.evaluate_assembly_instruction();
 
-  // Then: The result you get back is the symbol 'finale
+  // Then: The accumulator will hold the symbol 'finale
 
   ASSERT_EQ(hvm.get_accumulator()->get<Symbol>(), Symbol("finale"));
 

--- a/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
+++ b/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
@@ -6,6 +6,7 @@
 #include "shaka_scheme/system/base/Data.hpp"
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
 #include "shaka_scheme/system/base/Environment.hpp"
+#include "shaka_scheme/system/vm/CallFrame.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
 
 using namespace shaka;
@@ -322,5 +323,318 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
 
   ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
             Symbol("halt"));
+
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (assign var x) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_assign) {
+
+  // Given: An Accumulator with the Symbol("accumulator");
+
+  Accumulator acc = std::make_shared<Data>(Symbol("accumulator"));
+
+  // Given: An assembly instruction of the form (assign a (halt))
+  Symbol instruction("assign");
+  Data instruction_data(instruction);
+
+  Symbol halt("halt");
+  Data halt_data(halt);
+  DataPair halt_pair(halt_data);
+
+  Symbol var("a");
+  Data var_data(var);
+  DataPair var_halt_pair(var_data, *core::list(create_node(halt_pair)));
+
+  DataPair assign_var_halt(instruction_data, var_halt_pair);
+
+  NodePtr expression = std::make_shared<Data>(assign_var_halt);
+
+  // Given: An EnvPtr that points to an empty environment
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: An empty ValueRib
+
+  ValueRib vr;
+
+  // Given: A HeapVirtualMachine instance constructed with these items
+
+  HeapVirtualMachine hvm(acc, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction() method
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The environment register will contain the binding [a : accumulator]
+
+  ASSERT_EQ(hvm.get_environment()->get_value(Symbol("a"))->get<Symbol>(),
+            Symbol("accumulator"));
+
+  // Then: The next expression will be (halt)
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+            Symbol("halt"));
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (frame x ret) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_frame) {
+
+  // Given: An Accumulator containing the Symbol("finale")
+
+  Accumulator accumulator = std::make_shared<Data>(Symbol("finale"));
+
+  // Given: An assembly instruction of the form (frame (halt) (halt))
+
+  Symbol halt("halt");
+
+  Data halt_data(halt);
+
+  DataPair halt_pair(halt_data);
+
+  DataPair halt_halt(halt_pair, *core::list(create_node(halt_pair)));
+
+  Symbol frame("frame");
+  Data frame_data(frame);
+
+  DataPair frame_halt_halt(frame_data, halt_halt);
+
+  NodePtr expression = std::make_shared<Data>(frame_halt_halt);
+
+  // Given: An EnvPtr with bindings [a : "Hello", b : "World"]
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  env->set_value(Symbol("a"), std::make_shared<Data>(String("Hello")));
+  env->set_value(Symbol("b"), std::make_shared<Data>(String("World")));
+
+  // Given: A ValueRib containing strings "RVal1" "RVal2" "RVal3"
+
+  ValueRib vr = {create_node(String("RVal1")),
+                 create_node(String("RVal2")),
+                 create_node(String("RVal3"))};
+
+  // Given: A HeapVirtualMachine instance constructed with these items
+
+  HeapVirtualMachine hvm(accumulator, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction() method
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The control stack register has a new CallFrame
+
+  ASSERT_NE(hvm.get_call_frame(), nullptr);
+
+  // Then: The new CallFrame has an environment with bindings for a and b
+
+  ASSERT_EQ(
+      hvm.get_call_frame()->
+          get_environment_pointer()->
+          get_value(Symbol("a"))->get<String>(),
+      String("Hello"));
+
+  ASSERT_EQ(
+    hvm.get_call_frame()->
+        get_environment_pointer()->
+        get_value(Symbol("b"))->get<String>(),
+    String("World")
+  );
+
+  // Then: The new CallFrame has a ValueRib with "RVal1" "RVal2" "RVal3"
+
+  ASSERT_EQ(
+    hvm.get_call_frame()->
+        get_value_rib()[0]->get<String>(),
+    String("RVal1")
+  );
+
+  ASSERT_EQ(
+    hvm.get_call_frame()->
+        get_value_rib()[1]->get<String>(),
+    String("RVal2")
+  );
+
+  ASSERT_EQ(
+    hvm.get_call_frame()->
+        get_value_rib()[2]->get<String>(),
+    String("RVal3")
+  );
+
+  // Then: The new CallFrame has a next expression that is (halt)
+
+  ASSERT_EQ(hvm.get_call_frame()->
+      get_next_expression()->
+      get<DataPair>().car()->get<Symbol>(),
+  Symbol("halt"));
+
+  // Then: The new CallFrame has a next reference that is nullptr
+
+  ASSERT_EQ(hvm.get_call_frame()->get_next_frame(), nullptr);
+
+  // Then: The HVM instance will have an empty ValueRib register
+
+  ASSERT_EQ(hvm.get_value_rib().size(), 0);
+
+  // Then: The HVM instance's Expression register will contain (halt)
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+  Symbol("halt"));
+
+  // When: You invoke the evaluate_assembly_instruction() method again
+
+  auto result = hvm.evaluate_assembly_instruction();
+
+  // Then: It will return the contents of the Accumulator
+
+  ASSERT_EQ(result->get<Symbol>(), Symbol("finale"));
+
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (argument x) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_argument) {
+
+  // Given: An Accumulator containing the symbol 'banana
+
+  Symbol banana("banana");
+
+  Accumulator accumulator = create_node(banana);
+
+  // Given: An assembly instruction of the form (argument (halt))
+
+  Symbol halt("halt");
+  Data halt_data(halt);
+  DataPair halt_pair(halt_data);
+
+  Symbol argument("argument");
+  Data argument_data(argument);
+  DataPair argument_halt(argument, *core::list(create_node(halt_pair)));
+
+  NodePtr expression = create_node(argument_halt);
+
+  // Given: An EnvPtr to an empty Environment
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: An empty ValueRib
+
+  ValueRib vr;
+
+  // Given: An instance of the VM constructed with these items
+
+  HeapVirtualMachine hvm(accumulator, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction() method on hvm
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The ValueRib register will hold the Symbol("banana");
+
+  ASSERT_EQ(hvm.get_value_rib()[0]->get<Symbol>(), Symbol("banana"));
+
+  // Then: The Expression register will hold the instruction (halt)
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+  Symbol("halt"));
+
+  // When: You invoke the evaluate_assembly_instruction() method again
+
+  auto result = hvm.evaluate_assembly_instruction();
+
+  // Then: You will get back the banana that is in the Accumulator
+
+  ASSERT_EQ(result->get<Symbol>(), Symbol("banana"));
+
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (return) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_return) {
+
+  // Given: An Accumulator containing the symbol 'finale
+
+  Accumulator accumulator = create_node(Symbol("finale"));
+
+  // Given: An assembly instruction of the form (return)
+
+  Symbol ret("return");
+  Data return_data(ret);
+  DataPair return_pair(return_data);
+
+  NodePtr expression = create_node(return_pair);
+
+  // Given: An EnvPtr to an empty Environment
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: An empty ValueRib
+
+  ValueRib vr;
+
+  // Given: A CallFrame constructed as follows
+
+  EnvPtr call_frame_env = std::make_shared<Environment>(nullptr);
+  call_frame_env->set_value(Symbol("a"), create_node(String("Hello")));
+  call_frame_env->set_value(Symbol("b"), create_node(String("World")));
+
+  ValueRib call_frame_vr = {
+      create_node(String("VR1")),
+      create_node(String("VR2"))
+  };
+
+  Symbol halt("halt");
+  Data halt_data(halt);
+  DataPair halt_pair(halt_data);
+
+  NodePtr call_frame_exp = create_node(halt_pair);
+
+  FramePtr frame =
+      std::make_shared<CallFrame>(call_frame_exp, call_frame_env,
+                                  call_frame_vr, nullptr);
+
+  // Given: An instance of the HVM constructed with these items
+
+  HeapVirtualMachine hvm(accumulator, expression, env, vr, frame);
+
+  // When: You invoke the evaluate_assembly_instruction() method on hvm
+
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The HVM's Environment register will have the bindings for a & b
+
+  ASSERT_EQ(hvm.get_environment()->get_value(Symbol("a"))->get<String>(),
+  String("Hello"));
+
+  ASSERT_EQ(hvm.get_environment()->get_value(Symbol("b"))->get<String>(),
+  String("World"));
+
+  // Then: The HVM's ValueRib register will contain "VR1" and "VR2"
+
+  ASSERT_EQ(hvm.get_value_rib()[0]->get<String>(), String("VR1"));
+
+  ASSERT_EQ(hvm.get_value_rib()[1]->get<String>(), String("VR2"));
+
+  // Then: The HVM's ControlStack (FramePtr) register will be nullptr
+
+  ASSERT_EQ(hvm.get_call_frame(), nullptr);
+
+  // Then: The HVM's Expression register will contain (halt)
+
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+  Symbol("halt"));
+
+  // When: You invoke the evaluate_assembly_instruction method again
+
+  auto result = hvm.evaluate_assembly_instruction();
+
+  // Then: The result you get back is the symbol 'finale
+
+  ASSERT_EQ(result->get<Symbol>(), Symbol("finale"));
 
 }

--- a/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
+++ b/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
@@ -1,0 +1,89 @@
+//
+// Created by Billy Wooton on 10/2/17.
+//
+
+#include <gmock/gmock.h>
+#include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
+#include "shaka_scheme/system/base/Environment.hpp"
+
+using namespace shaka;
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (halt) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_halt) {
+
+  // Given: An accumulator that holds a NodePtr with symbol 'result
+  Symbol acc_value("result");
+  NodePtr accumulator = std::make_shared<Data>(acc_value);
+
+  // Given: An assembly instruction of the form (halt)
+  Symbol instruction("halt");
+  Data instruction_data(instruction);
+  DataPair instruction_pair(instruction_data);
+  NodePtr expression = std::make_shared<Data>(instruction_pair);
+
+  // Given: A pointer to an Environment with a null parent pointer
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: An empty ValueRib
+  ValueRib vr;
+
+  // Given: A HeapVirtualMachine instance constructed with these items
+  HeapVirtualMachine hvm (accumulator, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction() method
+  auto result = hvm.evaluate_assembly_instruction();
+
+  // Then: It will return the contents of the accumulator register
+  ASSERT_EQ(result->get<Symbol>(), Symbol("result"));
+
+}
+
+/**
+ * @brief Test: evaluate_assembly_instruction() with (refer var x) as exp
+ */
+TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
+  // Given: An assembly instruction of the form (refer a (halt))
+  Symbol instruction("refer");
+  Symbol var("a");
+  Symbol next_instr("halt");
+
+  Data next_instr_data(next_instr);
+  DataPair next_instr_pair(next_instr_data);
+
+  Data var_data(var);
+  DataPair var_x_pair(var, next_instr_pair);
+
+  Data instruction_data(instruction);
+  DataPair refer_var_x(instruction_data, var_x_pair);
+
+  NodePtr expression = std::make_shared<Data>(refer_var_x);
+
+  // Given: A pointer to Environment containing a binding for the symbol 'a
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+  env->set_value(Symbol("a"), create_node(String("test")));
+
+  // Given: An empty value rib
+  ValueRib vr;
+
+  // Given: A HeapVirtualMachine instance constructed with these items
+  HeapVirtualMachine hvm(nullptr, expression, env, vr, nullptr);
+
+  // When: You invoke the evaluate_assembly_instruction() method
+  hvm.evaluate_assembly_instruction();
+
+  // Then: The string "test" which was bound to 'a will be in the accumulator
+  ASSERT_EQ(hvm.get_accumulator(), env->get_value(Symbol("a")));
+
+  // Then: The next_expression will be (halt)
+  ASSERT_EQ(hvm.get_expression()->get<DataPair>().car()->get<Symbol>(),
+            Symbol("halt"));
+
+  // When: You then invoke the evaluate_assembly_instruction() method again
+  auto result = hvm.evaluate_assembly_instruction();
+
+  // Then: It will return the contents of the accumulator
+  ASSERT_EQ(result, env->get_value(Symbol("a")));
+}


### PR DESCRIPTION
Hello Guys,

Here is the first pull request for the HeapVirtualMachine. 8 of the 12 assembly instructions have been implemented as part of the `evaluate_assembly_instruction()` method in the HeapVirtualMachine class. Unit tests have been written for each of these instructions verifying the VM's ability to correctly evaluate them and modify its own state accordingly. Please look over the implementation as well as the unit tests, and let me know if you see anything that looks strange. I verified that my inputs to the method, i.e. `(refer var (halt))` or `(test (constant "then" (halt)) (constant "else" (halt)))` were well formed by printing the respective NodePtr contents of the expressions to standard output.

Once this pull request is merged, all that will be left to do is implement Closure/Continuation and then integrate it with the last 4 assembly instructions that depend on the presence of Closures and Continuations to function.