### PR TITLE
Migrated old Token and Tokenizer code

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,8 +1,31 @@
 #include <iostream>
 
 #include "shaka_scheme/system/exceptions/BaseException.hpp"
+#include "shaka_scheme/system/lexer/Tokenizer.hpp"
 
 int main() {
-  std::cout << "Hello, World!" << std::endl;
+  std::cout << "Welcome to Shaka Scheme!" << std::endl;
+
+  bool done = false;
+  shaka::Token token(shaka::Token::Type::END_OF_FILE, "\0");
+  shaka::Tokenizer input(std::cin);
+  while (!done) {
+    std::cout << "> " << std::flush;
+    try {
+      token = input.get();
+      std::cout << token << std::endl;
+      if (token.get_type() == shaka::Token::Type::DIRECTIVE) {
+        if (token.get_string() == std::string("quit")) {
+          done = true;
+        }
+      }
+    } catch (shaka::BaseException e) {
+      std::cerr << e.what() << std::endl;
+      std::cin.clear();
+      std::cin.ignore(INT_MAX);
+    }
+  }
+
+  std::cout << "Exiting..." << std::endl;
   return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <limits> // for std::numeric_limits for std::cin.ignore()
 
 #include "shaka_scheme/system/exceptions/BaseException.hpp"
 #include "shaka_scheme/system/lexer/Tokenizer.hpp"
@@ -22,7 +23,7 @@ int main() {
     } catch (shaka::BaseException e) {
       std::cerr << e.what() << std::endl;
       std::cin.clear();
-      std::cin.ignore(INT_MAX);
+      std::cin.ignore(std::numeric_limits<int>::max());
     }
   }
 

--- a/src/shaka_scheme/system/exceptions/TokenizerException.hpp
+++ b/src/shaka_scheme/system/exceptions/TokenizerException.hpp
@@ -1,0 +1,28 @@
+//
+// Created by LOS on 10/10/2017.
+//
+
+#ifndef SHAKA_SCHEME_TOKENIZEREXCEPTION_HPP
+#define SHAKA_SCHEME_TOKENIZEREXCEPTION_HPP
+
+#include "shaka_scheme/system/exceptions/BaseException.hpp"
+#include <string>
+
+namespace shaka {
+
+/**
+ * @brief Represents exceptions from the Tokenizer.
+ */
+class TokenizerException : public BaseException {
+public:
+  TokenizerException(
+      std::size_t exception_id,
+      const std::string& message) :
+      BaseException(
+          exception_id,
+          std::string("Tokenizer: ") + message) {}
+};
+
+} // namespace shaka
+
+#endif //SHAKA_SCHEME_TOKENIZEREXCEPTION_HPP

--- a/src/shaka_scheme/system/lexer/Token.hpp
+++ b/src/shaka_scheme/system/lexer/Token.hpp
@@ -1,0 +1,88 @@
+#ifndef SHAKA_LEXER_TOKEN_H
+#define SHAKA_LEXER_TOKEN_H
+
+#include <iostream>
+#include <string>
+
+namespace shaka {
+
+struct Token {
+public:
+  enum class Type : int {
+    INVALID = 255,
+    IDENTIFIER = 1,
+    BOOLEAN_TRUE = 2,
+    BOOLEAN_FALSE = 3,
+    NUMBER = 4,
+    CHARACTER = 5,
+    STRING = 6,
+    PAREN_START = 7,
+    VECTOR_START = 8,
+    BYTEVECTOR_START = 9,
+    PAREN_END = 10,
+    QUOTE = 11,
+    BACKTICK = 12,
+    COMMA = 13,
+    COMMA_ATSIGN = 14,
+    PERIOD = 15,
+    DATUM_COMMENT = 16,
+    COMMENT_START = 17,
+    COMMENT_END = 18,
+    DIRECTIVE = 19,
+    END_OF_FILE = 0
+  };
+
+  Token::Type type;
+  std::string str;
+  int line_no;
+  int col_no;
+
+  Token(Token::Type type) :
+      type(type),
+      str("") {}
+
+  Token(Token::Type type, const std::string& str) :
+      type(type),
+      str(str) {}
+
+  bool operator==(const Token& other) {
+    return (this->type == other.type &&
+        this->str == other.str);
+  }
+
+  bool operator!=(const Token& other) {
+    return !(operator==(other));
+  }
+
+  shaka::Token::Type get_type() const {
+    return this->type;
+  }
+
+  std::string get_string() const {
+    return this->str;
+  }
+
+  friend bool operator==(const Token& lhs, const Token& rhs);
+  friend bool operator!=(const Token& lhs, const Token& rhs);
+
+};
+
+std::ostream& operator<<(std::ostream& out, Token rhs) {
+  out << "Token(" << static_cast<int>(rhs.type) << ",\"" << rhs.str << "\")";
+  return out;
+}
+
+bool operator==(const Token& lhs, const Token& rhs) {
+  return (
+      lhs.type == rhs.type &&
+          lhs.str == rhs.str
+  );
+}
+
+bool operator!=(const Token& lhs, const Token& rhs) {
+  return !operator==(lhs, rhs);
+}
+
+} // namespace shaka
+
+#endif // SHAKA_LEXER_TOKEN_H

--- a/src/shaka_scheme/system/lexer/Tokenizer.hpp
+++ b/src/shaka_scheme/system/lexer/Tokenizer.hpp
@@ -573,23 +573,8 @@ public:
         while (!is_delimiter(in.peek())) {
           buffer += in.get();
         }
-        // fold-case directive?
-        if (buffer == "fold-case") {
-          result = Token(Token::Type::DIRECTIVE, "fold-case");
-          return true;
-          // no-fold-case directive?
-        } else if (buffer == "no-fold-case") {
-          result = Token(Token::Type::DIRECTIVE, "no-fold-case");
-          return true;
-        } else {
-          if (DEBUG_PRINT) {
-            std::cerr << "BROKE ON: " << in.peek() << std::endl;
-          }
-          throw shaka::TokenizerException(20010, "Tokenizer.parse_token: "
-              "invalid directive");
-          result = Token(Token::Type::END_OF_FILE);
-          return false;
-        }
+        result = Token(Token::Type::DIRECTIVE, buffer);
+        return true;
       } else {
         if (DEBUG_PRINT) {
           std::cerr << "BROKE ON: " << in.peek() << std::endl;

--- a/src/shaka_scheme/system/lexer/Tokenizer.hpp
+++ b/src/shaka_scheme/system/lexer/Tokenizer.hpp
@@ -1,0 +1,926 @@
+#ifndef SHAKA_LEXER_TOKENIZER_H
+#define SHAKA_LEXER_TOKENIZER_H
+
+#include "shaka_scheme/system/lexer/Token.hpp"
+#include "shaka_scheme/system/exceptions/TokenizerException.hpp"
+
+#include <iostream>
+#include <string>
+#include <deque>
+
+#ifndef DEBUG_PRINT
+#define DEBUG_PRINT 0
+#else
+#define DEBUG_PRINT 1
+#endif
+
+namespace shaka {
+
+class Tokenizer {
+private:
+  std::istream& in;
+  std::deque<Token> tokens;
+public:
+  Tokenizer(std::istream& in) :
+      in(in) {}
+
+  Token get() {
+    if (!tokens.empty()) {
+      auto front = tokens.front();
+      tokens.pop_front();
+      return front;
+    } else {
+      try {
+        this->read_next_token();
+      } catch (shaka::TokenizerException e) {
+        std::cerr << e.what() << std::endl;
+        throw e;
+      }
+      auto front = tokens.front();
+      tokens.pop_front();
+      return front;
+    }
+  }
+
+  Token peek() {
+    if (!tokens.empty()) {
+      auto front = tokens.front();
+      return front;
+    } else {
+      try {
+        this->read_next_token();
+      } catch (shaka::TokenizerException e) {
+        std::cerr << e.what() << std::endl;
+        throw e;
+      }
+      auto front = tokens.front();
+      return front;
+    }
+  }
+
+  void unget(Token t) {
+    tokens.push_front(t);
+  }
+
+  void read_next_token() {
+    Token t = parse_token();
+    if (DEBUG_PRINT) {
+      std::cerr << "Parsed: " << static_cast<int>(t.type)
+                << " :: " << t.str << std::endl;
+    }
+    tokens.push_back(t);
+  }
+
+  Token parse_paren_start() {
+    // Begin parenthesis
+    if (in.peek() == '(') {
+      in.get();
+      return Token(Token::Type::PAREN_START, "(");
+    } else {
+      throw shaka::TokenizerException(20000, "Could not parse Token"
+          ".PAREN_START");
+    }
+  }
+
+  Token parse_paren_end() {
+    if (in.peek() == ')') {
+      in.get();
+      return Token(Token::Type::PAREN_END, ")");
+    } else {
+      throw shaka::TokenizerException(20001, "Could not parse Token.PAREN_END");
+    }
+  }
+
+  void parse_string_element(std::string& str) {
+    if (in.peek() == '\\') {
+      in.get();
+      // what type of escape?
+      if (std::isalpha(in.peek())) {
+        // Any of the mnemonic escapes?
+        if (in.peek() == 'a') {
+          in.get();
+          str += '\a';
+          return;
+        } else if (in.peek() == 'b') {
+          in.get();
+          str += '\b';
+          return;
+        } else if (in.peek() == 't') {
+          in.get();
+          str += '\t';
+          return;
+        } else if (in.peek() == 'n') {
+          in.get();
+          str += '\n';
+          return;
+        } else if (in.peek() == 'r') {
+          in.get();
+          str += '\r';
+          return;
+
+          // If the first letter is 'x', then possibly hex digit
+        } else if (in.peek() == 'x') {
+          in.get();
+
+          // If the next character is a hex digit,
+          // then go into hex scalar value.
+          if (is_hex_digit(in.peek())) {
+            Token result(Token::Type::INVALID);
+            if (parse_hex_scalar_value_character(result)) {
+              str += result.str;
+              return;
+            } else {
+              str += "x";
+            }
+
+            // Otherwise, it's just a literal 'x'
+          } else {
+            str += "x";
+            return;
+          }
+
+
+          // Otherwise, it's going to either be a single character escape
+          // or a named character escape.
+        } else {
+          if (DEBUG_PRINT) {
+            std::cerr << "in single/named char escape" << std::endl;
+          }
+          std::string buffer;
+          while (!is_delimiter(in.peek()) && in.peek() != EOF) {
+            buffer += in.get();
+          }
+          if (DEBUG_PRINT) {
+            std::cerr << "buffer: " << buffer << std::endl;
+            std::cerr << "buffer.size(): " << buffer.size() << std::endl;
+          }
+          // If escape for whitespace, read in whitespace and then
+          // continue reading string elements.
+          if (std::isspace(in.peek()) && buffer.size() == 0) {
+            while (std::isspace(in.peek())) {
+              in.get();
+            }
+            return;
+
+            // named character escape?
+          } else if (buffer == "alarm") {
+            str += "\a";
+            return;
+          } else if (buffer == "backspace") {
+            str += "\b";
+            return;
+          } else if (buffer == "delete") {
+            str += "\x7F";
+            return;
+          } else if (buffer == "escape") {
+            str += "\x1B";
+            return;
+          } else if (buffer == "newline") {
+            str += "\n";
+            return;
+          } else if (buffer == "null") {
+            str += "\0";
+            return;
+          } else if (buffer == "return") {
+            str += "\r";
+            return;
+          } else if (buffer == "space") {
+            str += " ";
+            return;
+          } else if (buffer == "tab") {
+            str += "\t";
+            return;
+
+            // Otherwise, error!
+          } else {
+            throw shaka::TokenizerException(20002, "Tokenizer.parse_token: Bad "
+                "character escape");
+            return;
+          }
+        } // character escape
+        // Else, literal " or etc.
+      } else if (in.peek() == '\"') {
+        in.get();
+        str += "\"";
+        return;
+      } else {
+        str += in.peek();
+        in.get();
+      }
+    } else {
+      str += in.peek();
+      in.get();
+    }
+  }
+
+  Token parse_string() {
+    // String
+    if (in.peek() == '\"') {
+      in.get();
+      // Read in the rest of the string.
+      std::string buffer;
+      while (in.peek() != '\"') {
+        parse_string_element(buffer);
+      }
+      in.get();
+      return Token(Token::Type::STRING, buffer);
+    } else {
+      throw shaka::TokenizerException(20003, "Could not parse Token.STRING");
+    }
+  }
+
+  void parse_line_comment() {
+    if (DEBUG_PRINT) {
+      std::cout << "What LINE COMMENT is this? \'" <<
+                in.peek() << "\'" << std::endl;
+    }
+    // If it's a comment, read until the
+    // end of the lie.
+    while (in.peek() != '\n') {
+      in.get();
+    }
+    in.get();
+  }
+
+  bool parse_hex_scalar_value_character(Token& result) {
+    if (is_hex_digit(in.peek())) {
+      std::string buffer;
+      while (is_hex_digit(in.peek())) {
+        buffer += in.get();
+      }
+      int i = std::stoi(buffer, 0, 16);
+      buffer.clear();
+      buffer += static_cast<char>(i);
+      result = Token(Token::Type::CHARACTER, buffer);
+      return true;
+    } else {
+      throw shaka::TokenizerException(20004,
+                                      "Could not parse CHARACTER.hex_scalar_value");
+    }
+  }
+
+  bool parse_bytevector_byte(std::string& str) {
+    if (std::isdigit(in.peek())) {
+      std::string buffer;
+      while (std::isdigit(in.peek())) {
+        buffer += in.get();
+      }
+      int num = std::stoi(buffer);
+      if (num >= 0 && num <= 255) {
+        str += buffer;
+        return true;
+      } else {
+        if (DEBUG_PRINT) {
+          std::cerr << "Tokenizer.parse_bytevector_byte: Not in range [0, 255]"
+                    << std::endl;
+        }
+        throw shaka::TokenizerException(20005,
+                                        "Tokenizer.parse_bytevector_byte: Not in range [0, 255]");
+        return false;
+      }
+
+    } else {
+      if (DEBUG_PRINT) {
+        std::cerr << "Tokenizer.parse_bytevector_byte: Not a digit"
+                  << std::endl;
+      }
+      throw shaka::TokenizerException(20006,
+                                      "Tokenizer.parse_bytevector_byte: Not a digit");
+      return false;
+    }
+  }
+
+  bool rule_hash(Token& result) {
+    if (in.peek() == '#') {
+      in.get();
+
+      // vector start token
+      if (in.peek() == '(') {
+        in.get();
+        result = Token(Token::Type::VECTOR_START, "#(");
+        return true;
+
+        // <bytevector> ==> #u8( <byte>* )
+        // Just read in the start token.
+      } else if (in.peek() == 'u') {
+        in.get();
+        if (in.peek() == '8') {
+          in.get();
+          if (in.peek() == '(') {
+            in.get();
+            result = Token(Token::Type::BYTEVECTOR_START, "#u8(");
+            return true;
+          }
+        } else {
+          if (DEBUG_PRINT) {
+            std::cerr << "bytevector: failed to read in 8 after u" << std::endl;
+          }
+          throw shaka::TokenizerException(20007,
+                                          "Tokenizer.rule_hash: bytevector invalid prefix");
+          return false;
+        }
+
+        // <character>
+      } else if (in.peek() == '\\') {
+        in.get();
+        if (DEBUG_PRINT) {
+          std::cerr << "in character" << std::endl;
+        }
+
+        // what type of escape?
+        if (std::isalpha(in.peek())) {
+          // If the first letter is 'x', then possibly hex digit
+          if (in.peek() == 'x') {
+            in.get();
+
+            // If the next character is a hex digit,
+            // then go into hex scalar value.
+            if (is_hex_digit(in.peek())) {
+              return parse_hex_scalar_value_character(result);
+
+              // Otherwise, it's just a literal 'x'
+            } else {
+              result = Token(Token::Type::CHARACTER, "x");
+              return true;
+            }
+
+            // Otherwise, it's going to either be a single character escape
+            // or a named character escape.
+          } else {
+            if (DEBUG_PRINT) {
+              std::cerr << "in single/named char escape" << std::endl;
+            }
+            std::string buffer;
+            while (!is_delimiter(in.peek()) && in.peek() != EOF) {
+              buffer += in.get();
+            }
+            if (DEBUG_PRINT) {
+              std::cerr << "buffer: " << buffer << std::endl;
+              std::cerr << "buffer.size(): " << buffer.size() << std::endl;
+            }
+            // single character escape?
+            if (buffer.size() == 1) {
+              result = Token(Token::Type::CHARACTER, buffer);
+
+              // named character escape?
+            } else if (buffer == "alarm") {
+              result = Token(Token::Type::CHARACTER, "\a");
+              return true;
+            } else if (buffer == "backspace") {
+              result = Token(Token::Type::CHARACTER, "\b");
+              return true;
+            } else if (buffer == "delete") {
+              result = Token(Token::Type::CHARACTER, "\x7F");
+              return true;
+            } else if (buffer == "escape") {
+              result = Token(Token::Type::CHARACTER, "\x1B");
+              return true;
+            } else if (buffer == "newline") {
+              result = Token(Token::Type::CHARACTER, "\n");
+              return true;
+            } else if (buffer == "null") {
+              result = Token(Token::Type::CHARACTER, "\0");
+              return true;
+            } else if (buffer == "return") {
+              result = Token(Token::Type::CHARACTER, "\r");
+              return true;
+            } else if (buffer == "space") {
+              result = Token(Token::Type::CHARACTER, " ");
+              return true;
+            } else if (buffer == "tab") {
+              result = Token(Token::Type::CHARACTER, "\t");
+              return true;
+
+              // Otherwise, error!
+            } else {
+              throw "Tokenizer.parse_token: Bad character escape";
+              result = Token(Token::Type::END_OF_FILE);
+              return false;
+            }
+          } // character escape
+        }
+
+        // <boolean> #t or #true?
+      } else if (in.peek() == 't') {
+
+        std::string buffer;
+        while (std::isalpha(in.peek())) {
+          buffer += in.get();
+        }
+        if (buffer == "true" || buffer == "t") {
+          result = Token(Token::Type::BOOLEAN_TRUE, "#t");
+          return true;
+        } else {
+          throw shaka::TokenizerException(20008, "Tokenizer.parse_token: "
+              "invalid hash identifier/boolean does not match to true");
+          result = Token(Token::Type::END_OF_FILE);
+          return false;
+        }
+        // <boolean> #f or #false?
+      } else if (in.peek() == 'f') {
+        std::string buffer;
+        while (std::isalpha(in.peek())) {
+          buffer += in.get();
+        }
+        if (buffer == "false" || buffer == "f") {
+          result = Token(Token::Type::BOOLEAN_FALSE, "#f");
+          return true;
+        } else {
+          throw shaka::TokenizerException(20009, "Tokenizer.parse_token: "
+              "invalid hash identifier/boolean does not match to true");
+          result = Token(Token::Type::END_OF_FILE);
+          return false;
+        }
+        // Nested comment must keep track
+        // of depth.
+      } else if (in.peek() == '|') {
+        int depth_count = 1;
+        while (depth_count > 0) {
+          if (in.peek() == '|') {
+            in.get();
+            if (in.peek() == '#') {
+              in.get();
+              depth_count--;
+            }
+          } else if (in.peek() == '#') {
+            in.get();
+            if (in.peek() == '|') {
+              in.get();
+              depth_count++;
+            }
+          } else {
+            if (DEBUG_PRINT) {
+              std::cerr << "What is this? \'" << in.peek()
+                        << "\'" << std::endl;
+            }
+            in.get();
+          }
+        }
+        return false;
+
+        // Single datum comment.
+      } else if (in.peek() == ';') {
+        in.get();
+        result = Token(Token::Type::DATUM_COMMENT, "#;");
+        return true;
+
+        // Directive
+      } else if (in.peek() == '!') {
+        in.get();
+
+        // Read in the directive string.
+        std::string buffer;
+        while (!is_delimiter(in.peek())) {
+          buffer += in.get();
+        }
+        // fold-case directive?
+        if (buffer == "fold-case") {
+          result = Token(Token::Type::DIRECTIVE, "fold-case");
+          return true;
+          // no-fold-case directive?
+        } else if (buffer == "no-fold-case") {
+          result = Token(Token::Type::DIRECTIVE, "no-fold-case");
+          return true;
+        } else {
+          if (DEBUG_PRINT) {
+            std::cerr << "BROKE ON: " << in.peek() << std::endl;
+          }
+          throw shaka::TokenizerException(20010, "Tokenizer.parse_token: "
+              "invalid directive");
+          result = Token(Token::Type::END_OF_FILE);
+          return false;
+        }
+      } else {
+        if (DEBUG_PRINT) {
+          std::cerr << "BROKE ON: " << in.peek() << std::endl;
+        }
+        throw shaka::TokenizerException(20011, "Tokenizer.parse_token: invalid "
+            "hash directive");
+        result = Token(Token::Type::END_OF_FILE);
+        return false;
+      }
+    } else {
+      if (DEBUG_PRINT) {
+        std::cerr << "BROKE ON: " << in.peek() << std::endl;
+      }
+      throw shaka::TokenizerException(20012, "Tokenizer.parse_token: is not a "
+          "hash? wrong");
+      result = Token(Token::Type::END_OF_FILE);
+      return false;
+    }
+
+    /// @todo Need to make sure why the compiler gives a
+    ///       warning why it doesn't think it may
+    ///       not return a value.
+    return false;
+  }
+
+  Token parse_number(std::string& buffer) {
+
+    bool number = false;
+    // Parse sign if it's there
+    if (is_explicit_sign(in.peek())) {
+      buffer += in.get();
+    }
+    // Parse the integer part.
+    while (std::isdigit(in.peek())) {
+      buffer += in.get();
+
+      number = true;
+    }
+
+    // Parse in a dot if it's a float
+    if (in.peek() == '.') {
+      buffer += in.get();
+
+      // Parse in the fractional integer part.
+      while (std::isdigit(in.peek())) {
+        buffer += in.get();
+      }
+
+      number = true;
+    }
+
+    // If there is a /, it is a fraction
+    if (in.peek() == '/') {
+      buffer += in.get();
+
+      while (std::isdigit(in.peek())) {
+        buffer += in.get();
+
+        number = true;
+      }
+    }
+    //
+    //  // Make sure that it's the end of the number
+    //  if (is_delimiter(in.peek())) {
+    //      return Token(Token::Type::NUMBER, buffer);
+    //  } else {
+    //      if (DEBUG_PRINT) {
+    //          std::cerr << "Tokenizer.parse_number: Did not find following delimiter" << std::endl;
+    //      }
+    //      throw shaka::TokenizerException("Tokenizer.parse_number: Did not find following delimiter");
+    //      return Token(Token::Type::INVALID);
+    //  }
+    //
+
+    if (number == true) {
+      return Token(Token::Type::NUMBER, buffer);
+    } else {
+      return Token(Token::Type::INVALID);
+    }
+  }
+
+  Token parse_token() {
+    bool done = false;
+    while (!done) {
+      // Quote
+      if (in.peek() == '\'') {
+        in.get();
+        return Token(Token::Type::QUOTE, "\'");
+
+        // Backtick
+      } else if (in.peek() == '`') {
+        in.get();
+        return Token(Token::Type::BACKTICK, "`");
+
+        // Comma
+      } else if (in.peek() == ',') {
+        in.get();
+        // Comma at-sign.
+        if (in.peek() == '@') {
+          in.get();
+          return Token(Token::Type::COMMA_ATSIGN, ",@");
+        } else {
+          return Token(Token::Type::COMMA, ",");
+        }
+
+      } else if (in.peek() == '.') {
+        in.get();
+        return Token(Token::Type::PERIOD, ".");
+
+        // Begin parenthesis
+      } else if (in.peek() == '(') {
+        return parse_paren_start();
+
+        // End parenthesis
+      } else if (in.peek() == ')') {
+        return parse_paren_end();
+
+        // String
+      } else if (in.peek() == '\"') {
+        return parse_string();
+
+        // Line comment
+      } else if (in.peek() == ';') {
+        parse_line_comment();
+        // Then, continue and get next token to parse.
+        done = false;
+
+        // End of file
+      } else if (in.peek() == EOF) {
+        if (DEBUG_PRINT) {
+          std::cerr << "What EOF is this? \'" << in.peek() << "\'" << std::endl;
+        }
+        in.get();
+        return Token(Token::Type::END_OF_FILE);
+
+        // Skip whitespace
+      } else if (std::isspace(in.peek())) {
+        if (DEBUG_PRINT) {
+          std::cerr << "What space is this? \'" << in.peek() << "\'"
+                    << std::endl;
+        }
+        in.get();
+        done = false;
+
+        // Comment or boolean begins with #
+      } else if (in.peek() == '#') {
+        Token result(Token::Type::END_OF_FILE);
+        if (rule_hash(result)) {
+          return result;
+        } else {
+          done = false;
+        }
+
+        // Identifier ==> <initial> <subsequent>*
+      } else if (is_initial(in.peek())) {
+        if (DEBUG_PRINT) {
+          std::cout << "What INITIAL is this? \'" << in.peek() << "\'"
+                    << std::endl;
+        }
+        std::string buffer;
+        buffer += in.get();
+        // Keep getting subsequent if needed.
+        while (is_subsequent(in.peek())) {
+          buffer += in.get();
+        }
+        return Token(Token::Type::IDENTIFIER, buffer);
+
+        // Identifier ==> <vertical line> <symbol element>* <vertical line>
+      } else if (in.peek() == '|') {
+        in.get();
+        std::string buffer;
+        while (handle_symbol_element(in, buffer));
+        if (in.peek() == '|') {
+          in.get();
+          return Token(Token::Type::IDENTIFIER, buffer);
+        } else {
+          throw shaka::TokenizerException(20013, "Tokenizer.parse_token: "
+              "invalid pipe-delimted identifier syntax");
+          return Token(Token::Type::END_OF_FILE);
+        }
+
+        // Identifier ==> <explicit sign> ...
+      } else if (is_explicit_sign(in.peek())) {
+        std::string buffer;
+        buffer += in.get();
+        // <sign subsequent> <subsequent>*
+        if (is_sign_subsequent(in.peek())) {
+          buffer = +in.get();
+          while (is_subsequent(in.peek())) {
+            buffer += in.get();
+          }
+          return Token(Token::Type::IDENTIFIER, buffer);
+          // . <dot subsequent> <subsequent>*
+        } else if (in.peek() == '.') {
+          buffer += in.get();
+          if (is_dot_subsequent(in.peek())) {
+            buffer += in.get();
+            while (is_subsequent(in.peek())) {
+              buffer += in.get();
+            }
+            return Token(Token::Type::IDENTIFIER, buffer);
+
+            // if it's a digit, it's probably a number
+          } else if (std::isdigit(in.peek())) {
+            return parse_number(buffer);
+
+            // no <dot subsequent> ==> error!
+          } else {
+            throw shaka::TokenizerException(20014, "Tokenizer.parse_token: bad "
+                "dot subsequent identifier");
+            return Token(Token::Type::END_OF_FILE);
+          }
+
+          // Parse in a number
+        } else if (std::isdigit(in.peek())) {
+          std::string buffer;
+          return parse_number(buffer);
+
+          // No other identifier? Just <explicit sign> is fine.
+        } else {
+          return Token(Token::Type::IDENTIFIER, buffer);
+        }
+
+        // Identifier ==> . <dot subsequent> <subsequent>
+      } else if (in.peek() == '.') {
+        std::string buffer;
+        buffer += in.get();
+        if (is_dot_subsequent(in.peek())) {
+          buffer += in.get();
+          while (is_subsequent(in.peek())) {
+            buffer += in.get();
+          }
+          return Token(Token::Type::IDENTIFIER, buffer);
+        } else {
+          throw shaka::TokenizerException(20015, "Tokenizer.parse_token: bad "
+              "dot subsequent identifier");
+          return Token(Token::Type::END_OF_FILE);
+        }
+
+        // <number> ==> <num 10> for now
+        /// @todo Add real, rational, complex for different radixes.
+      } else if (std::isdigit(in.peek())) {
+        std::string buffer;
+        return parse_number(buffer);
+
+        // NOT A VALID TOKEN!!!
+      } else {
+        if (DEBUG_PRINT) {
+          std::cerr << "BROKE ON: " << in.peek() << std::endl;
+        }
+        throw shaka::TokenizerException(20016, "Tokenizer.parse_token: invalid "
+            "token");
+        return Token(Token::Type::END_OF_FILE);
+      }
+    }
+    throw 1;
+    return Token(Token::Type::END_OF_FILE);
+  }
+
+  bool is_delimiter(char c) {
+    return (
+        std::isspace(c)
+            || c == '|'
+            || c == '('
+            || c == ')'
+            || c == '\"'
+            || c == ';'
+    );
+  }
+
+  bool is_special_initial(char c) {
+    return (
+        c == '!' ||
+            c == '$' ||
+            c == '%' ||
+            c == '&' ||
+            c == '*' ||
+            c == '/' ||
+            c == '!' ||
+            c == ':' ||
+            c == '>' ||
+            c == '=' ||
+            c == '>' ||
+            c == '?' ||
+            c == '^' ||
+            c == '_' ||
+            c == '!'
+    );
+  }
+
+  bool is_special_subsequent(char c) {
+    return (
+        c == '.'
+            || c == '@'
+            || is_explicit_sign(c)
+    );
+  }
+
+  bool is_explicit_sign(char c) {
+    return (c == '+' || c == '-');
+  }
+
+  bool is_letter(char c) {
+    return (std::isalpha(c));
+  }
+
+  bool is_subsequent(char c) {
+    return (is_initial(c)
+        || is_digit(c)
+        || is_special_subsequent(c));
+  }
+
+  bool is_initial(char c) {
+    return (is_letter(c) || is_special_initial(c));
+  }
+
+  bool is_digit(char c) {
+    return (std::isdigit(c));
+  }
+
+  bool handle_symbol_element(std::istream& in, std::string& interm) {
+
+    // Terminating symbol
+    if (in.peek() == '|') {
+      return false;
+
+      // Escape sequence
+    } else if (in.peek() == '\\') {
+      in.get();
+      // inline_hex_escape?
+      if (in.peek() == 'x') {
+        in.get();
+        return (handle_inline_hex_escape(in, interm));
+
+        // mnemonic_escape?
+      } else if (in.peek() == 'a') {
+        in.get();
+        interm += '\a';
+        return true;
+      } else if (in.peek() == 'b') {
+        in.get();
+        interm += '\b';
+        return true;
+      } else if (in.peek() == 't') {
+        in.get();
+        interm += '\t';
+        return true;
+      } else if (in.peek() == 'n') {
+        in.get();
+        interm += '\n';
+        return true;
+      } else if (in.peek() == 'r') {
+        in.get();
+        interm += '\r';
+        return true;
+
+        // escape for pipe character?
+      } else if (in.peek() == '|') {
+        in.get();
+        interm += '|';
+        return true;
+
+        // otherwise, invalid!
+      } else {
+        throw shaka::TokenizerException(20017,
+                                        "Tokenizer.mnemonic_escape: invalid escape character");
+        return false;
+      }
+
+      // Otherwise, just consume the next character.
+    } else {
+      interm += in.get();
+      return true;
+    }
+  }
+
+  bool is_dot_subsequent(char c) {
+    return (is_sign_subsequent(c) || c == '.');
+  }
+
+  bool handle_inline_hex_escape(std::istream& in, std::string& interm) {
+    char c = in.peek();
+    std::string buffer;
+    while (
+        std::isdigit(c)
+            || c == 'a'
+            || c == 'b'
+            || c == 'c'
+            || c == 'd'
+            || c == 'e'
+            || c == 'f'
+        ) {
+      in.get();
+      buffer += c;
+      c = in.peek();
+    }
+    // Correct form ==> push character onto interm string.
+    if (in.peek() == ';') {
+      int i = std::stoi(buffer, 0, 16);
+      interm += static_cast<char>(i);
+      return true;
+
+      // incorect form ==> error!
+    } else {
+      throw shaka::TokenizerException(20018, "Tokenizer"
+          ".handle_inline_hex_escape: no terminating \';\' character");
+      return false;
+    }
+  }
+
+  bool is_sign_subsequent(char c) {
+    return (
+        is_initial(c)
+            || is_explicit_sign(c)
+            || c == '@'
+    );
+  }
+
+  bool is_hex_digit(char c) {
+    return (
+        std::isdigit(c)
+            || c == 'a'
+            || c == 'b'
+            || c == 'c'
+            || c == 'd'
+            || c == 'e'
+            || c == 'f'
+    );
+  }
+};
+
+} // namespace shaka
+
+#endif // SHAKA_LEXER_TOKENIZER_H

--- a/tst/shaka_scheme/system/CMakeLists.txt
+++ b/tst/shaka_scheme/system/CMakeLists.txt
@@ -2,4 +2,4 @@ add_subdirectory(base)
 add_subdirectory(exceptions)
 add_subdirectory(core)
 add_subdirectory(vm)
-
+add_subdirectory(lexer)

--- a/tst/shaka_scheme/system/lexer/CMakeLists.txt
+++ b/tst/shaka_scheme/system/lexer/CMakeLists.txt
@@ -1,0 +1,1 @@
+macro_shaka_scheme_test(unit-Tokenizer)

--- a/tst/shaka_scheme/system/lexer/unit-Tokenizer.cpp
+++ b/tst/shaka_scheme/system/lexer/unit-Tokenizer.cpp
@@ -4,10 +4,13 @@
 
 #include <sstream>
 
+/**
+ * @brief Test: parsing a number.
+ */
 TEST(TokenizerUnitTest, number) {
   // Given: a stream with "1" loaded
   std::stringstream ss;
-  ss << "1";
+  ss << "12345.123";
   // Given: a Tokenizer getting input from the stream
   shaka::Tokenizer tokenizer(ss);
 
@@ -16,5 +19,183 @@ TEST(TokenizerUnitTest, number) {
 
   // Then: the next token should be a number with string "1"
   ASSERT_EQ(token.get_type(), shaka::Token::Type::NUMBER);
-  ASSERT_EQ(token.get_string(), "1");
+  ASSERT_EQ(token.get_string(), "12345.123");
+}
+
+/**
+ * @brief Test: reading in a (define asdf 1) procedure call
+ */
+TEST(TokenizerUnitTest, define_procedure_call) {
+  // Given: a stringstream initialized with input
+  std::stringstream ss("( define\nasdf\t1    )");
+  // Given: a Tokenizer initialized with the stringstream
+  shaka::Tokenizer tk(ss);
+
+  using shaka::Token;
+  // Given: a sequence of tokens to match
+  std::vector<shaka::Token> v = {
+      {Token::Type::PAREN_START, "("},
+      {Token::Type::IDENTIFIER, "define"},
+      {Token::Type::IDENTIFIER, "asdf"},
+      {Token::Type::NUMBER, "1"},
+      {Token::Type::PAREN_END, ")"}
+  };
+
+  // When: the Tokenizer reads input into Tokens one by one until end of file
+  // Then: the read Tokens should match the expected sequence in v
+  int index = 0;
+  for (auto t = tk.get();
+       t.type != shaka::Token::Type::END_OF_FILE;
+       t = tk.get(), ++index) {
+    ASSERT_EQ(v[index], t);
+  }
+}
+
+/**
+ * @brief Test: parsing a flawed list sequence with line comment.
+ */
+TEST(TokenizerUnitTest, flawed_list_and_comment) {
+  // Given: an istream with input string
+  std::stringstream ss("( \"asdf\" ) ; asdfasdfasdf\n)");
+  // Given: a Tokenizer initialized with istream&
+  shaka::Tokenizer tokenizer(ss);
+
+  // Type alias for convenience
+  using Type = shaka::Token::Type;
+
+  // Given: a sequence of Token to match to
+  std::vector<shaka::Token> expected{
+      shaka::Token(Type::PAREN_START, "("),
+      shaka::Token(Type::STRING, "asdf"),
+      shaka::Token(Type::PAREN_END, ")"),
+      shaka::Token(Type::PAREN_END, ")")
+  };
+
+  std::vector<shaka::Token> input;
+  // When: you get and push tokens into the vector while the tokenizer reads
+  do {
+    shaka::Token t = tokenizer.get();
+    if (t != Type::END_OF_FILE) {
+      input.push_back(t);
+    } else {
+      break;
+    }
+  } while (true);
+
+
+  // Then: the read-in Tokens should match the expected in v
+  for (unsigned i = 0; i < input.size(); ++i) {
+    ASSERT_EQ(input[i], expected[i]);
+  }
+}
+
+/**
+ * @brief Test: reading in identifiers
+ */
+TEST(TokenizerUnitTest, identifiers) {
+
+  using Type = shaka::Token::Type;
+
+  // Given: a stringstream initialized to a string
+  std::stringstream ss1("(\t quantifier + / asdf \"qwer\"\n)");
+
+  // Given: a vector of Tokens to match to
+  std::vector<shaka::Token> expected = {
+      shaka::Token(Type::PAREN_START, "("),
+      shaka::Token(Type::IDENTIFIER, "quantifier"),
+      shaka::Token(Type::IDENTIFIER, "+"),
+      shaka::Token(Type::IDENTIFIER, "/"),
+      shaka::Token(Type::IDENTIFIER, "asdf"),
+      shaka::Token(Type::STRING, "qwer"),
+      shaka::Token(Type::PAREN_END, ")")
+  };
+
+  // When: you read in input into Tokens that are inserted into a vectot
+  std::vector<shaka::Token> input;
+  shaka::Tokenizer tokenizer1(ss1);
+  do {
+    shaka::Token t = tokenizer1.get();
+    if (t != Type::END_OF_FILE) {
+      input.push_back(t);
+    } else {
+      break;
+    }
+  } while (true);
+
+  // Then: the read-in tokens should match the expected
+  for (unsigned i = 0; i < input.size(); ++i) {
+    ASSERT_EQ(input[i], expected[i]);
+  }
+}
+
+/**
+ * @brief Test: reading a piped identifier
+ */
+TEST(TokenizerUnitTest, piped_identifier) {
+
+  // Given: two vectors to hold the expected and input Tokens
+  using Type = shaka::Token::Type;
+  std::vector<shaka::Token> expected;
+  std::vector<shaka::Token> input;
+
+  // Given: a stringstream to use as the basis for input.
+  std::stringstream ss2("|asdf\t\n$$|");
+
+  // Given: the expected input
+  expected.clear();
+  expected = {
+      shaka::Token(Type::IDENTIFIER, "asdf\t\n$$"),
+  };
+
+  // When: you read in the input Tokens and place them into the input vector
+  input.clear();
+  shaka::Tokenizer tokenizer2(ss2);
+  do {
+    shaka::Token t = tokenizer2.get();
+    if (t != shaka::Token(Type::END_OF_FILE)) {
+      input.push_back(t);
+    } else {
+      break;
+    }
+  } while (true);
+
+  // Then: they should match that in expected
+  for (unsigned i = 0; i < input.size(); ++i) {
+    ASSERT_EQ(input[i], expected[i]);
+  }
+}
+
+/**
+ * @brief Test: commenting and whitespace hash escapes
+ */
+TEST(TokenizerUnitTest, comment_whitespace_escapes) {
+  using Type = shaka::Token::Type;
+  // Given: an input stream initialized with a string
+  std::stringstream ss3("#\\newline #\\t");
+
+  // Given: a vector of expected Tokens to match to
+  std::vector<shaka::Token> expected = {
+      shaka::Token(Type::CHARACTER, "\n"),
+      shaka::Token(Type::CHARACTER, "t"),
+  };
+
+  // When: the input is read into Tokens
+  std::vector<shaka::Token> input;
+  shaka::Tokenizer tokenizer3(ss3);
+  do {
+    shaka::Token t = tokenizer3.get();
+    if (t != shaka::Token(Type::END_OF_FILE)) {
+      input.push_back(t);
+    } else {
+      break;
+    }
+  } while (true);
+
+  // Then: the whitespace escape sequences should've been translated into the
+  // correct string representations stored within the Token, and match the
+  // expected characters.
+  for (unsigned i = 0; i < input.size(); ++i) {
+    ASSERT_EQ(input[i], expected[i]);
+  }
+
 }

--- a/tst/shaka_scheme/system/lexer/unit-Tokenizer.cpp
+++ b/tst/shaka_scheme/system/lexer/unit-Tokenizer.cpp
@@ -1,0 +1,20 @@
+#include "shaka_scheme/system/lexer/Tokenizer.hpp"
+
+#include <gmock/gmock.h>
+
+#include <sstream>
+
+TEST(TokenizerUnitTest, number) {
+  // Given: a stream with "1" loaded
+  std::stringstream ss;
+  ss << "1";
+  // Given: a Tokenizer getting input from the stream
+  shaka::Tokenizer tokenizer(ss);
+
+  // When: you get the next token
+  shaka::Token token = tokenizer.get();
+
+  // Then: the next token should be a number with string "1"
+  ASSERT_EQ(token.get_type(), shaka::Token::Type::NUMBER);
+  ASSERT_EQ(token.get_string(), "1");
+}


### PR DESCRIPTION
I've migrated the old `Token` and `Tokenizer` classes. From all the testing that occurred last semester, I believe they're minimally viable for supporting Scheme.

The two major changes I've made are to the unit tests and to the `#!<directive>` rule. Usually, Scheme accepts just `#!no-fold-case` and #!fold-case` but I've made it so that any other string, even the empty one, is not an error. This is so that we can use `#!quit` to end the REPL. It's very useful.

**Please check that the test cases look sane.**
**Please check that the REPL code looks not too complex.**
**Please check that the Doxygen-formatted comments for the `Tokenizer` class are well-written.**

Note: The documentation for `Tokenzier` is unfinished because it's just too big. I'm putting of the work for it and adding a `@todo` marker to explicitly mark the documentation as unfinished.