### PR TITLE
Final pull request for HeapVirtualMachine

### DIFF
--- a/src/shaka_scheme/system/base/Data.cpp
+++ b/src/shaka_scheme/system/base/Data.cpp
@@ -34,6 +34,10 @@ shaka::Data::Data(const shaka::Data& other) :
     new(&closure) shaka::Closure(other.closure);
     break;
   }
+  case shaka::Data::Type::CALL_FRAME: {
+    new(&call_frame) shaka::CallFrame(other.call_frame);
+    break;
+  }
 //  case shaka::Data::Type::DATA_NODE: {
 //    new(&data_node) std::shared_ptr<shaka::DataNode>(other.data_node);
 //    break;
@@ -81,6 +85,10 @@ shaka::Data::~Data() {
   }
   case shaka::Data::Type::CLOSURE: {
     this->closure.~Closure();
+    break;
+  }
+  case shaka::Data::Type::CALL_FRAME: {
+    this->call_frame.~CallFrame();
     break;
   }
 //  case shaka::Data::Type::ENVIRONMENT: {
@@ -135,6 +143,14 @@ shaka::Closure& shaka::Data::get<shaka::Closure>() {
   return this->closure;
 }
 
+template<>
+shaka::CallFrame& shaka::Data::get<shaka::CallFrame>() {
+  if (this->get_type() != Type::CALL_FRAME) {
+    throw new shaka::TypeException(8, "Could not get() CallFrame from Data");
+  }
+  return this->call_frame;
+}
+
 namespace shaka {
 
 std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs) {
@@ -186,6 +202,12 @@ std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs) {
     lhs << "#<procedure>";
     break;
   }
+
+  case shaka::Data::Type::CALL_FRAME: {
+    lhs << "#<stack-frame>";
+    break;
+  }
+
   case shaka::Data::Type::ENVIRONMENT: {
     throw shaka::MissingImplementationException(1337,
                                                 "Environment printing is not supported "

--- a/src/shaka_scheme/system/base/Data.cpp
+++ b/src/shaka_scheme/system/base/Data.cpp
@@ -30,6 +30,10 @@ shaka::Data::Data(const shaka::Data& other) :
     new(&data_pair) shaka::DataPair(other.data_pair);
     break;
   }
+  case shaka::Data::Type::CLOSURE: {
+    new(&closure) shaka::Closure(other.closure);
+    break;
+  }
 //  case shaka::Data::Type::DATA_NODE: {
 //    new(&data_node) std::shared_ptr<shaka::DataNode>(other.data_node);
 //    break;
@@ -75,6 +79,10 @@ shaka::Data::~Data() {
     this->data_pair.~DataPair();
     break;
   }
+  case shaka::Data::Type::CLOSURE: {
+    this->closure.~Closure();
+    break;
+  }
 //  case shaka::Data::Type::ENVIRONMENT: {
 //    this->environment::~environment();
 //    break;
@@ -117,6 +125,14 @@ shaka::DataPair& shaka::Data::get<shaka::DataPair>() {
     throw new shaka::TypeException(6, "Could not get() DataPair from Data");
   }
   return this->data_pair;
+}
+
+template<>
+shaka::Closure& shaka::Data::get<shaka::Closure>() {
+  if (this->get_type() != Type::CLOSURE) {
+    throw new shaka::TypeException(7, "Could not get() Closure from Data");
+  }
+  return this->closure;
 }
 
 namespace shaka {
@@ -165,6 +181,10 @@ std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs) {
                                                 "DataPair printing is not supported yet "
                                                     "(implement in Data.cpp after adding more helper functions for "
                                                     "determining whether the current item is a list, dotted pair, etc.)");
+  }
+  case shaka::Data::Type::CLOSURE: {
+    lhs << "#<procedure>";
+    break;
   }
   case shaka::Data::Type::ENVIRONMENT: {
     throw shaka::MissingImplementationException(1337,

--- a/src/shaka_scheme/system/base/Data.hpp
+++ b/src/shaka_scheme/system/base/Data.hpp
@@ -14,6 +14,7 @@
 #include "shaka_scheme/system/base/IEnvironment.hpp"
 #include "shaka_scheme/system/base/DataPair.hpp"
 #include "shaka_scheme/system/vm/Closure.hpp"
+#include "shaka_scheme/system/vm/CallFrame.hpp"
 
 
 #include <memory>
@@ -49,6 +50,7 @@ public:
     STRING,
     BOOLEAN,
     CLOSURE,
+    CALL_FRAME,
     NULL_LIST
   };
 private:
@@ -60,6 +62,7 @@ private:
     shaka::DataPair data_pair;
     shaka::Symbol symbol;
     shaka::Closure closure;
+    shaka::CallFrame call_frame;
   };
 
 public:
@@ -87,6 +90,11 @@ public:
   Data(shaka::Closure other) {
     new(&closure) shaka::Closure(other);
     this->type_tag = Type::CLOSURE;
+  }
+
+  Data(shaka::CallFrame other) {
+    new(&call_frame) shaka::CallFrame(other);
+    this->type_tag = Type::CALL_FRAME;
   }
 
   /**
@@ -135,6 +143,7 @@ template<> shaka::Symbol& shaka::Data::get<shaka::Symbol>();
 template<> shaka::Boolean& shaka::Data::get<shaka::Boolean>();
 template<> shaka::DataPair& shaka::Data::get<shaka::DataPair>();
 template<> shaka::Closure& shaka::Data::get<shaka::Closure>();
+template<> shaka::CallFrame& shaka::Data::get<shaka::CallFrame>();
 
 std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs);
 

--- a/src/shaka_scheme/system/base/Data.hpp
+++ b/src/shaka_scheme/system/base/Data.hpp
@@ -13,6 +13,8 @@
 #include "shaka_scheme/system/base/Boolean.hpp"
 #include "shaka_scheme/system/base/IEnvironment.hpp"
 #include "shaka_scheme/system/base/DataPair.hpp"
+#include "shaka_scheme/system/vm/Closure.hpp"
+
 
 #include <memory>
 
@@ -26,6 +28,8 @@ class DataNode;
 class Environment;
 class DataPair;
 class UserStructData;
+class Closure;
+class CallFrame;
 
 class Data;
 
@@ -44,6 +48,7 @@ public:
     NUMBER,
     STRING,
     BOOLEAN,
+    CLOSURE,
     NULL_LIST
   };
 private:
@@ -54,6 +59,7 @@ private:
     shaka::String string;
     shaka::DataPair data_pair;
     shaka::Symbol symbol;
+    shaka::Closure closure;
   };
 
 public:
@@ -76,6 +82,11 @@ public:
   Data(shaka::DataPair other) {
     new(&data_pair) shaka::DataPair(other);
     this->type_tag = Type::DATA_PAIR;
+  }
+
+  Data(shaka::Closure other) {
+    new(&closure) shaka::Closure(other);
+    this->type_tag = Type::CLOSURE;
   }
 
   /**
@@ -123,6 +134,7 @@ template<> shaka::String& shaka::Data::get<shaka::String>();
 template<> shaka::Symbol& shaka::Data::get<shaka::Symbol>();
 template<> shaka::Boolean& shaka::Data::get<shaka::Boolean>();
 template<> shaka::DataPair& shaka::Data::get<shaka::DataPair>();
+template<> shaka::Closure& shaka::Data::get<shaka::Closure>();
 
 std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs);
 

--- a/src/shaka_scheme/system/core/lists.hpp
+++ b/src/shaka_scheme/system/core/lists.hpp
@@ -13,44 +13,44 @@
 namespace shaka {
 namespace core {
 
-NodePtr cons(NodePtr left, NodePtr right) {
+inline NodePtr cons(NodePtr left, NodePtr right) {
   return create_node(Data(DataPair(left, right)));
 }
 
-NodePtr car(NodePtr node) {
+inline NodePtr car(NodePtr node) {
   if (node->get_type() != Data::Type::DATA_PAIR) {
     throw shaka::TypeException(10001, "car(): Data does not hold DataPair");
   }
   return node->get<DataPair>().car();
 }
 
-NodePtr cdr(NodePtr node) {
+inline NodePtr cdr(NodePtr node) {
   if (node->get_type() != Data::Type::DATA_PAIR) {
     throw shaka::TypeException(10001, "car(): Data does not hold DataPair");
   }
   return node->get<DataPair>().cdr();
 }
 
-void set_car(NodePtr pair, NodePtr obj) {
+inline void set_car(NodePtr pair, NodePtr obj) {
   if (pair->get_type() != Data::Type::DATA_PAIR) {
     throw shaka::TypeException(10001, "set_car(): Data does not hold DataPair");
   }
   pair->get<DataPair>().set_car(obj);
 }
 
-void set_cdr(NodePtr pair, NodePtr obj) {
+inline void set_cdr(NodePtr pair, NodePtr obj) {
   if (pair->get_type() != Data::Type::DATA_PAIR) {
     throw shaka::TypeException(10001, "set_cdr(): Data does not hold DataPair");
   }
   pair->get<DataPair>().set_cdr(obj);
 }
 
-NodePtr list() {
+inline NodePtr list() {
   return create_node(Data());
 }
 
 template <typename... Args>
-NodePtr list(NodePtr first, Args... rest) {
+inline NodePtr list(NodePtr first, Args... rest) {
   return shaka::core::cons(first, shaka::core::list(rest...));
 }
 
@@ -59,16 +59,18 @@ NodePtr list(NodePtr first, Args... rest) {
  * @param node The node to examine.
  * @return true if object is a pair, false if otherwise.
  */
-bool is_pair(NodePtr node) {
+inline bool is_pair(NodePtr node) {
   return node->get_type() == Data::Type::DATA_PAIR;
 }
 
 
-bool is_null_list(NodePtr node) {
+inline bool is_null_list(NodePtr node) {
   return node->get_type() == Data::Type::NULL_LIST;
 }
 
-bool is_proper_list(NodePtr node) {
+inline bool is_proper_list(NodePtr node) {
+  // The empty list is a proper list
+  if (is_null_list(node)) { return true; }
   // Lists must be pairs.
   if (!is_pair(node)) { return false; }
   // Get the last cdr of the last pair in the
@@ -81,7 +83,7 @@ bool is_proper_list(NodePtr node) {
   return is_null_list(it);
 }
 
-bool is_improper_list(NodePtr node) {
+inline bool is_improper_list(NodePtr node) {
   // Lists must be pairs.
   if (!is_pair(node)) { return false; }
   // Get the last cdr of the last pair in the
@@ -94,7 +96,7 @@ bool is_improper_list(NodePtr node) {
   return !is_null_list(it);
 }
 
-std::size_t length(NodePtr node) {
+inline std::size_t length(NodePtr node) {
   if (node->get_type() == shaka::Data::Type::NULL_LIST) {
     return 0;
   }
@@ -112,15 +114,15 @@ std::size_t length(NodePtr node) {
   return count;
 }
 
-NodePtr append() {
+inline NodePtr append() {
   return list();
 }
 
-NodePtr append(NodePtr first) {
+inline NodePtr append(NodePtr first) {
   return first;
 }
 
-NodePtr append(NodePtr first, NodePtr second) {
+inline NodePtr append(NodePtr first, NodePtr second) {
   // The first argument must be a proper list.
   if (!is_proper_list(first)) {
     throw shaka::TypeException(2002, "append(): first argument is not a "
@@ -172,7 +174,7 @@ NodePtr append(NodePtr first, NodePtr second) {
 }
 
 template <typename... Args>
-NodePtr append(NodePtr first, NodePtr second, Args... rest) {
+inline NodePtr append(NodePtr first, NodePtr second, Args... rest) {
   auto node = append(first, second);
   return append(node, rest...);
 }

--- a/src/shaka_scheme/system/core/types.hpp
+++ b/src/shaka_scheme/system/core/types.hpp
@@ -15,7 +15,7 @@ namespace core {
  * @param node The data to take in
  * @return A boolean of whether the predicate was satisfied.
  */
-bool is_boolean(NodePtr node) {
+inline bool is_boolean(NodePtr node) {
   return node->get_type() == Data::Type::BOOLEAN;
 }
 
@@ -24,7 +24,7 @@ bool is_boolean(NodePtr node) {
  * @param node The data to take in
  * @return A boolean of whether the predicate was satisfied.
  */
-bool is_symbol(NodePtr node) {
+inline bool is_symbol(NodePtr node) {
   return node->get_type() == Data::Type::SYMBOL;
 }
 
@@ -33,7 +33,7 @@ bool is_symbol(NodePtr node) {
  * @param node The data to take in
  * @return A boolean of whether the predicate was satisfied.
  */
-bool is_string(NodePtr node) {
+inline bool is_string(NodePtr node) {
   return node->get_type() == Data::Type::STRING;
 }
 
@@ -50,7 +50,7 @@ bool is_string(NodePtr node) {
  * system. Here, we provide this function to act as the type predicate for the
  * "unspecified" value.
  */
-bool is_unspecified(NodePtr node) {
+inline bool is_unspecified(NodePtr node) {
   return node->get_type() == Data::Type::UNSPECIFIED;
 }
 
@@ -60,7 +60,7 @@ bool is_unspecified(NodePtr node) {
  *
  * @implementation_specific
  */
-NodePtr create_unspecified_node() {
+inline NodePtr create_unspecified_node() {
   return shaka::create_unspecified();
 }
 
@@ -70,7 +70,7 @@ NodePtr create_unspecified_node() {
  * @param right The right object
  * @return A boolean denoting the equivalence predicate
  */
-bool is_eqv(NodePtr left, NodePtr right) {
+inline bool is_eqv(NodePtr left, NodePtr right) {
   auto left_type = left->get_type();
   auto right_type = right->get_type();
   if (left_type != right_type) {

--- a/src/shaka_scheme/system/vm/CallFrame.cpp
+++ b/src/shaka_scheme/system/vm/CallFrame.cpp
@@ -19,7 +19,7 @@ shaka::CallFrame::CallFrame(shaka::Expression ret,
 shaka::CallFrame::CallFrame() {
   return_expression = std::make_shared<Data>();
   env = std::make_shared<Environment>(nullptr);
-  value_rib = std::vector<NodePtr>(0);
+  value_rib = std::deque<NodePtr>(0);
   next_frame = nullptr;
 }
 

--- a/src/shaka_scheme/system/vm/CallFrame.cpp
+++ b/src/shaka_scheme/system/vm/CallFrame.cpp
@@ -2,7 +2,9 @@
 // Created by Billy Wooton on 9/18/17.
 //
 
-#include "CallFrame.hpp"
+#include "shaka_scheme/system/vm/CallFrame.hpp"
+#include "shaka_scheme/system/base/Data.hpp"
+
 
 
 shaka::CallFrame::CallFrame(shaka::Expression ret,
@@ -13,6 +15,13 @@ shaka::CallFrame::CallFrame(shaka::Expression ret,
   env(env),
   value_rib(rib),
   next_frame(next_frame) {}
+
+shaka::CallFrame::CallFrame() {
+  return_expression = std::make_shared<Data>();
+  env = std::make_shared<Environment>(nullptr);
+  value_rib = std::vector<NodePtr>(0);
+  next_frame = nullptr;
+}
 
 
 shaka::Expression shaka::CallFrame::get_next_expression() {

--- a/src/shaka_scheme/system/vm/CallFrame.hpp
+++ b/src/shaka_scheme/system/vm/CallFrame.hpp
@@ -2,11 +2,12 @@
 // Created by Billy Wooton on 9/14/17.
 //
 
-#ifndef SHAKA_SCHEME_CONTROLFRAME_HPP
-#define SHAKA_SCHEME_CONTROLFRAME_HPP
+#ifndef SHAKA_SCHEME_CALLFRAME_HPP
+#define SHAKA_SCHEME_CALLFRAME_HPP
 
 #include "shaka_scheme/system/base/Environment.hpp"
 #include <vector>
+#include <deque>
 
 namespace shaka {
 
@@ -16,7 +17,7 @@ using NodePtr = std::shared_ptr<Data>;
 
 using EnvPtr = std::shared_ptr<Environment>;
 using FramePtr = std::shared_ptr<CallFrame>;
-using ValueRib = std::vector<NodePtr>;
+using ValueRib = std::deque<NodePtr>;
 using Expression = NodePtr;
 
 class CallFrame {

--- a/src/shaka_scheme/system/vm/CallFrame.hpp
+++ b/src/shaka_scheme/system/vm/CallFrame.hpp
@@ -5,12 +5,14 @@
 #ifndef SHAKA_SCHEME_CONTROLFRAME_HPP
 #define SHAKA_SCHEME_CONTROLFRAME_HPP
 
-#include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/base/Environment.hpp"
 #include <vector>
 
 namespace shaka {
 
 class CallFrame;
+class Data;
+using NodePtr = std::shared_ptr<Data>;
 
 using EnvPtr = std::shared_ptr<Environment>;
 using FramePtr = std::shared_ptr<CallFrame>;
@@ -31,6 +33,15 @@ public:
    */
   CallFrame(Expression ret, EnvPtr env, ValueRib rib, FramePtr
   next_frame);
+
+  /**
+   * @brief Default constructor for CallFrame
+   * Initializes the return expression to be the null list
+   * Initializes the environment to be an empty environment
+   * Intializes the value rib to be an empty vector of NodePtr
+   * Initializes the FramePtr to be a nullptr
+   */
+  CallFrame();
 
   /**
    * @brief Getter method for next_expression (return address)

--- a/src/shaka_scheme/system/vm/Closure.cpp
+++ b/src/shaka_scheme/system/vm/Closure.cpp
@@ -3,8 +3,13 @@
 //
 
 #include "shaka_scheme/system/vm/Closure.hpp"
+#include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/vm/CallFrame.hpp"
+
 
 namespace shaka {
+
+class Data;
 
 Closure::Closure(EnvPtr env,
                  NodePtr fb,
@@ -16,6 +21,17 @@ Closure::Closure(EnvPtr env,
     variable_list(vl),
     callable(cl),
     frame(frame) {}
+
+Closure::Closure() {
+  env = std::make_shared<Environment>(nullptr);
+  func_body = std::make_shared<Data>();
+  variable_list = std::vector<shaka::Symbol>(0);
+  callable = nullptr;
+  frame = std::make_shared<CallFrame>();
+
+}
+
+
 
 NodePtr Closure::get_function_body() {
   return this->func_body;

--- a/src/shaka_scheme/system/vm/Closure.cpp
+++ b/src/shaka_scheme/system/vm/Closure.cpp
@@ -4,8 +4,7 @@
 
 #include "shaka_scheme/system/vm/Closure.hpp"
 #include "shaka_scheme/system/base/Data.hpp"
-#include "shaka_scheme/system/vm/CallFrame.hpp"
-
+#include "shaka_scheme/system/core/lists.hpp"
 
 namespace shaka {
 
@@ -15,12 +14,14 @@ Closure::Closure(EnvPtr env,
                  NodePtr fb,
                  VariableList vl,
                  CallablePtr cl,
-                 FramePtr frame) :
+                 FramePtr frame,
+                 bool arity) :
     env(env),
     func_body(fb),
     variable_list(vl),
     callable(cl),
-    frame(frame) {}
+    frame(frame),
+    variable_arity(arity) {}
 
 Closure::Closure() {
   env = std::make_shared<Environment>(nullptr);
@@ -28,6 +29,7 @@ Closure::Closure() {
   variable_list = std::vector<shaka::Symbol>(0);
   callable = nullptr;
   frame = std::make_shared<CallFrame>();
+  variable_arity = false;
 
 }
 
@@ -38,16 +40,45 @@ NodePtr Closure::get_function_body() {
 }
 
 void Closure::extend_environment(ValueRib vr) {
-  for (size_t i = 0; i < variable_list.size(); i++) {
-    env->set_value(variable_list[i], vr[i]);
+
+  EnvPtr new_frame = std::make_shared<Environment>(env);
+
+  if (this->variable_arity) {
+
+    size_t i = 0;
+    // The var_args parameter should always be last in the variable list
+    while (i < variable_list.size() - 1) {
+      new_frame->set_value(variable_list[i], vr[i]);
+      i++;
+    }
+
+    if (i < vr.size()) {
+      NodePtr var_args = core::list();
+      for (;i < vr.size(); i++) {
+        var_args = core::append(var_args, core::list(vr[i]));
+      }
+      new_frame->set_value(
+          variable_list[variable_list.size() - 1],
+          var_args
+      );
+    }
+
   }
+
+  else {
+    for (size_t i = 0; i < variable_list.size(); i++) {
+      new_frame->set_value(variable_list[i], vr[i]);
+    }
+  }
+
+  this->env = new_frame;
 }
 
 EnvPtr Closure::get_environment() {
   return this->env;
 }
 
-std::vector<NodePtr> Closure::call(std::vector<NodePtr> args) {
+std::deque<NodePtr> Closure::call(std::deque<NodePtr> args) {
   return (*callable)(args);
 }
 
@@ -65,6 +96,10 @@ bool Closure::is_native_closure() {
 
 bool Closure::is_continuation_closure() {
   return this->frame != nullptr;
+}
+
+bool Closure::is_variable_arity() {
+  return this->variable_arity;
 }
 
 

--- a/src/shaka_scheme/system/vm/Closure.hpp
+++ b/src/shaka_scheme/system/vm/Closure.hpp
@@ -5,15 +5,18 @@
 #ifndef SHAKA_SCHEME_CLOSURE_HPP
 #define SHAKA_SCHEME_CLOSURE_HPP
 
-#include "shaka_scheme/system/base/Data.hpp"
-#include "shaka_scheme/system/base/DataPair.hpp"
 #include "shaka_scheme/system/base/Environment.hpp"
-#include "shaka_scheme/system/vm/CallFrame.hpp"
 #include <vector>
 #include <functional>
 
 namespace shaka {
 
+class Data;
+class CallFrame;
+
+using EnvPtr = std::shared_ptr<Environment>;
+using FramePtr = std::shared_ptr<CallFrame>;
+using ValueRib = std::vector<NodePtr>;
 using Callable = std::function<std::vector<NodePtr>(std::vector<NodePtr>)>;
 using CallablePtr = std::shared_ptr<Callable>;
 
@@ -32,6 +35,16 @@ public:
    */
   Closure(EnvPtr env, NodePtr fb, VariableList vl,
           CallablePtr cl, FramePtr frame);
+
+  /**
+   * @brief Default constructor for Closure class
+   * Initializes environment to be an empty environment
+   * Initializes function body to be the empty list
+   * Initializes the variable list to be an empty vector
+   * Initializes the callable to be a nullptr
+   * Initializes the FramePtr to point to a default frame
+   */
+  Closure();
 
   /**
    * @brief Method to get the body of the function

--- a/src/shaka_scheme/system/vm/Closure.hpp
+++ b/src/shaka_scheme/system/vm/Closure.hpp
@@ -7,6 +7,7 @@
 
 #include "shaka_scheme/system/base/Environment.hpp"
 #include <vector>
+#include <deque>
 #include <functional>
 
 namespace shaka {
@@ -16,8 +17,8 @@ class CallFrame;
 
 using EnvPtr = std::shared_ptr<Environment>;
 using FramePtr = std::shared_ptr<CallFrame>;
-using ValueRib = std::vector<NodePtr>;
-using Callable = std::function<std::vector<NodePtr>(std::vector<NodePtr>)>;
+using ValueRib = std::deque<NodePtr>;
+using Callable = std::function<std::deque<NodePtr>(std::deque<NodePtr>)>;
 using CallablePtr = std::shared_ptr<Callable>;
 
 using VariableList = std::vector<Symbol>;
@@ -34,7 +35,7 @@ public:
    * @param frame A pointer to a CallFrame, needed for continuations
    */
   Closure(EnvPtr env, NodePtr fb, VariableList vl,
-          CallablePtr cl, FramePtr frame);
+          CallablePtr cl, FramePtr frame, bool arity);
 
   /**
    * @brief Default constructor for Closure class
@@ -69,7 +70,7 @@ public:
    * @param args The arguments to the procedure
    * @return A vector containing the result(s) of the procedure call
    */
-  std::vector<NodePtr> call(std::vector<NodePtr> args);
+  std::deque<NodePtr> call(std::deque<NodePtr> args);
 
   /**
    * @brief A procedure to retrieve the CallFrame from a continuation closure
@@ -95,6 +96,12 @@ public:
    */
   bool is_continuation_closure();
 
+  /**
+   * @brief Method to determine whether or ot this Closure has variable arity
+   * @return true if this accepts a variable number of args, else false
+   */
+  bool is_variable_arity();
+
 
 
 private:
@@ -104,6 +111,7 @@ private:
   VariableList variable_list;
   CallablePtr callable;
   FramePtr frame;
+  bool variable_arity;
 
 };
 

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -194,6 +194,23 @@ void HeapVirtualMachine::evaluate_assembly_instruction() {
 
   }
 
+  // (apply)
+
+  if (instruction == shaka::Symbol("apply")) {
+    shaka::Closure& closure = this->get_accumulator()->get<Closure>();
+
+    if (closure.is_native_closure()) {
+      this->set_value_rib(closure.call(this->get_value_rib()));
+    }
+
+    else {
+      closure.extend_environment(this->get_value_rib());
+      this->set_environment(closure.get_environment());
+      this->set_value_rib(std::vector<NodePtr>(0));
+      this->set_expression(closure.get_function_body());
+    }
+  }
+
   // (return)
 
   if (instruction == shaka::Symbol("return")) {

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
-#include "shaka_scheme/system/vm/CallFrame.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
 
 namespace shaka {
@@ -117,6 +116,47 @@ void HeapVirtualMachine::evaluate_assembly_instruction() {
     this->env->set_value(var, this->acc);
 
     this->set_expression(expression);
+
+  }
+
+  // (conti x)
+
+  if (instruction == shaka::Symbol("conti")) {
+
+    // Create the function body for the continuation
+
+    NodePtr call_frame = std::make_shared<Data>(*this->frame);
+    NodePtr nuate = std::make_shared<Data>(Symbol("nuate"));
+    NodePtr var = std::make_shared<Data>(Symbol("kont_v000"));
+
+    // Create the variable list
+
+    std::vector<Symbol> vars;
+    vars.push_back(Symbol("kont_v000"));
+
+
+    // Create the continuation
+
+    NodePtr func_body = core::list(nuate, call_frame, var);
+    EnvPtr empty_env = std::make_shared<Environment>(nullptr);
+    NodePtr continuation =
+        std::make_shared<Data>(
+            Closure(
+                empty_env,
+                func_body,
+                vars,
+                nullptr,
+                this->frame
+            )
+        );
+
+    // Place the continuation in the accumulator
+
+    this->set_accumulator(continuation);
+
+    // Set the next expression register to x
+
+    this->set_expression(exp_pair.cdr()->get<DataPair>().car());
 
   }
 

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.hpp
@@ -6,7 +6,7 @@
 #define SHAKA_SCHEME_HEAPVIRTUALMACHINE_HPP
 
 
-#include <vector>
+#include <deque>
 #include "shaka_scheme/system/base/Data.hpp"
 
 namespace shaka {
@@ -29,7 +29,7 @@ class CallFrame;
 using Accumulator = NodePtr;
 using Expression = NodePtr;
 using EnvPtr = std::shared_ptr<Environment>;
-using ValueRib = std::vector<NodePtr>;
+using ValueRib = std::deque<NodePtr>;
 using FramePtr = std::shared_ptr<CallFrame>;
 
 
@@ -103,7 +103,7 @@ public:
    * @brief Restores parameter s to be the CurrentStack
    * @param s The pointer to a CallFrame to represent the new CurrentStack
    */
-  void push_call_frame(FramePtr s);
+  void set_call_frame(FramePtr s);
 
   /**
    * @brief Sets the value of the Environment register to be the parameter e

--- a/src/shaka_scheme/system/vm/strings.hpp
+++ b/src/shaka_scheme/system/vm/strings.hpp
@@ -15,15 +15,16 @@ namespace shaka {
 
 using Callable = std::function<std::vector<NodePtr>(std::vector<NodePtr>)>;
 
+namespace core {
+
 std::vector<NodePtr> str_append(std::vector<NodePtr> args) {
   if (args[0]->get_type() != Data::Type::STRING) {
     throw TypeException(10001, "Incompatible argument type to NativeClosure");
   }
 
-  String result(args[0]->get<String>());
+  String result("");
 
-
-  for (std::size_t i = 1; i < args.size(); i++) {
+  for (int i = args.size() - 1; i >= 0; i--) {
     result.append(args[i]->get<String>());
   }
 
@@ -31,7 +32,9 @@ std::vector<NodePtr> str_append(std::vector<NodePtr> args) {
   return results;
 }
 
-Callable string_append = str_append;
+}
+
+Callable string_append = core::str_append;
 
 }
 #endif //SHAKA_SCHEME_STRINGS_HPP

--- a/src/shaka_scheme/system/vm/strings.hpp
+++ b/src/shaka_scheme/system/vm/strings.hpp
@@ -13,22 +13,22 @@
 
 namespace shaka {
 
-using Callable = std::function<std::vector<NodePtr>(std::vector<NodePtr>)>;
+using Callable = std::function<std::deque<NodePtr>(std::deque<NodePtr>)>;
 
 namespace core {
 
-std::vector<NodePtr> str_append(std::vector<NodePtr> args) {
+std::deque<NodePtr> str_append(std::deque<NodePtr> args) {
   if (args[0]->get_type() != Data::Type::STRING) {
     throw TypeException(10001, "Incompatible argument type to NativeClosure");
   }
 
   String result("");
 
-  for (int i = args.size() - 1; i >= 0; i--) {
+  for (std::size_t i = 0; i < args.size(); i++) {
     result.append(args[i]->get<String>());
   }
 
-  std::vector<NodePtr> results = {create_node(result)};
+  std::deque<NodePtr> results = {create_node(result)};
   return results;
 }
 

--- a/tst/shaka_scheme/system/vm/CMakeLists.txt
+++ b/tst/shaka_scheme/system/vm/CMakeLists.txt
@@ -1,3 +1,4 @@
 macro_shaka_scheme_test(unit-HeapVirtualMachine)
 macro_shaka_scheme_test(unit-Closure)
 macro_shaka_scheme_test(unit-Compiler)
+

--- a/tst/shaka_scheme/system/vm/unit-Closure.cpp
+++ b/tst/shaka_scheme/system/vm/unit-Closure.cpp
@@ -4,6 +4,7 @@
 
 #include <gmock/gmock.h>
 #include "shaka_scheme/system/vm/Closure.hpp"
+#include "shaka_scheme/system/vm/CallFrame.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
 #include "shaka_scheme/system/vm/strings.hpp"
 

--- a/tst/shaka_scheme/system/vm/unit-Closure.cpp
+++ b/tst/shaka_scheme/system/vm/unit-Closure.cpp
@@ -48,7 +48,7 @@ TEST(ClosureUnitTest, constructor) {
   FramePtr call_frame = nullptr;
 
   // When: You construct a closure object with these items
-  Closure identity(env, body_expression, vars, callable, call_frame);
+  Closure identity(env, body_expression, vars, callable, call_frame, false);
 
   // Then: The body of the Closure will be (refer x (return))
 
@@ -100,7 +100,7 @@ TEST(ClosureUnitTest, extend_environment) {
   ValueRib vr = {create_node(String("Hello"))};
 
   // Given: A closure object constructed with these items
-  Closure identity(env, body_expression, vars, callable, call_frame);
+  Closure identity(env, body_expression, vars, callable, call_frame, false);
 
   // When: You extend the closure objects environment with the value rib
   identity.extend_environment(vr);
@@ -152,7 +152,7 @@ TEST(ClosureUnitTest, native_closure) {
   // Given: A Closure object constructed with these items
 
   Closure string_append_closure(env, body_expression,
-                                vars, string_append_ptr, call_frame);
+                                vars, string_append_ptr, call_frame, true);
 
   // When: You call the closure on the items in the ValueRib
 
@@ -180,19 +180,6 @@ TEST(ClosureUnitTest, continuation_closure) {
 
   std::vector<Symbol> vars = {Symbol("kont_v_000")};
 
-  // Given: The standard function body for a Continuation '(nuate s var)
-
-  /* A dummy symbol 's is being used here instead of the actual CallFrame
-   * because the Closure object will keep the CallFrame in a separate field
-   * from the function body. This removes the need to complicate the Data
-   * code by including CallFrame as a type of Data
-   */
-  NodePtr func_body = core::list(
-      create_node(Symbol("nuate")),
-      create_node(Symbol("s")),
-      create_node(Symbol("kont_v_000"))
-  );
-
   // Given: A pointer to a CallFrame object
 
   ValueRib vr;
@@ -204,9 +191,17 @@ TEST(ClosureUnitTest, continuation_closure) {
       nullptr
   );
 
+  // Given: The standard function body for a Continuation '(nuate s var)
+
+  NodePtr func_body = core::list(
+      create_node(Symbol("nuate")),
+      create_node((*frame)),
+      create_node(Symbol("kont_v_000"))
+  );
+
   // When: You construct a continuation Closure with these items
 
-  Closure continuation(env, func_body, vars, nullptr, frame);
+  Closure continuation(env, func_body, vars, nullptr, frame, false);
 
   // Then: The continuation Closure should be correctly identifiable as such
 
@@ -230,5 +225,67 @@ TEST(ClosureUnitTest, continuation_closure) {
               get_next_expression()->
               get<DataPair>().car()->get<Symbol>(), Symbol("return")
   );
+}
+
+/**
+ * @brief Test: Closure functionality with a variadic lambda
+ */
+TEST(ClosureUnitTest, variadic_lambda) {
+
+  // Simulation of the behavior of a procedure such as (lambda x x)
+
+  // Given: A pointer to an environment with no bindings
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  // Given: A variable list that just holds the variable 'x
+
+  VariableList vars{Symbol("x")};
+
+  // Given: A function body that is just a reference to the variable 'x
+
+  NodePtr func_body = core::list(
+      create_node(Symbol("refer")),
+      create_node(Symbol("x")),
+      core::list(
+          create_node(Symbol("return"))
+      )
+  );
+
+  // Given: A Closure that is constructed with these items
+
+  Closure variadic(env, func_body, vars, nullptr, nullptr, true);
+
+  // Given: A ValueRib containing the strings "Hello" "World" "Leaders"
+
+  ValueRib vr{
+      create_node(String("Hello")),
+      create_node(String("World")),
+      create_node(String("Leaders"))
+  };
+
+  // When: You extend the Closure's environment with the ValueRib
+
+  variadic.extend_environment(vr);
+
+  // Then: The environment referred to by the Closure will hold a list of
+  // the strings
+
+  ASSERT_EQ(
+      variadic.get_environment()->get_value(Symbol("x"))->get_type(),
+      Data::Type::DATA_PAIR
+  );
+
+  ASSERT_EQ(
+    variadic.get_environment()->
+        get_value(Symbol("x"))->get<DataPair>().car()->get<String>(),
+    String("Hello")
+  );
+
+  ASSERT_EQ(
+    core::length((variadic.get_environment()->get_value(Symbol("x")))),
+    static_cast<int>(3)
+  );
+
 }
 


### PR DESCRIPTION
Alright folks, here you have it. The final implementation of the `HeapVirtualMachine` is now complete. All twelve of the assembly instructions have been implemented and thoroughly tested. Barring certain slight inconsistencies in the assumptions made by the Compiler spelled out in the Three Implementation Models for Scheme paper in regards to the handling lambda expressions that have multiple body expressions, this VM code is test proven to represent a sound implementation of Dybvig's Heap Based Model. 

You'll notice that this pull request has a number of auxiliary commits that were needed to complement the finishing of the VM. 

`Closure` and `CallFrame` were both added to `shaka::Data` out of necessity. 

The type of the ValueRib data structure was changed from `std::vector` to `std::deque` in order to accurately reflect the semantics of being able to add arguments to the _front_ of the value rib when the `(argument ...)` instruction is executed by the VM. 

The functions in the `core/types.hpp` and `core/lists.hpp` were given an `inline` qualifier to allow `Closure.cpp` and `HeapVirtualMachine.cpp` to each include these functions without incurring linker errors, as both classes needed the functionality contained in these header files to do their work. 

Finally, variadic lambda support was added to the Closure class and tested. This is to enable our system to handle lambda defined procedures like `(lambda x x)` that take in a variable number of arguments, as well as those that have improper parameter lists like `(lambda (a b . c) ...)` 

Please look over this pull request at your earliest convenience, and feel free to let me know if you spot anything that looks dubious or that I might have overlooked in my testing. This turned out to be a much larger commit than I had originally foresaw, with a large number of diffs, so it is highly likely that I missed more than a few things along the way. The good news is, all of my test cases pass and the 12 instructions are complete and working properly, with lots of interoperability already proven.