### PR TITLE
Created MacroContext, basic scope tracking algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,8 @@ set(SOURCE_FILES
         src/shaka_scheme/system/vm/Closure.cpp
         src/shaka_scheme/system/vm/compiler/Compiler.cpp
         src/shaka_scheme/system/base/PrimitiveFormMarker.cpp
+        src/shaka_scheme/system/parser/syntax_rules/MacroContext.cpp
+        src/shaka_scheme/system/parser/syntax_rules/SyntaxRulesMacro.cpp
         )
 
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})

--- a/src/shaka_scheme/system/exceptions/MacroExpansionException.hpp
+++ b/src/shaka_scheme/system/exceptions/MacroExpansionException.hpp
@@ -1,0 +1,26 @@
+#ifndef SHAKA_SCHEME_MACROEXPANSIONEXCEPTION_HPP_
+#define SHAKA_SCHEME_MACROEXPANSIONEXCEPTION_HPP_
+
+#include "shaka_scheme/system/exceptions/BaseException.hpp"
+
+namespace shaka {
+
+/**
+ * @brief Represents macro expansion exceptions at macro expansion time.
+ *
+ * Used in the MacroContextChecker and macro expansion process.
+ */
+class MacroExpansionException : public shaka::BaseException {
+public:
+  /**
+   * @brief Initializes the BaseException.
+   * @param exception_id The unique exception type id.
+   * @param message The error message.
+   */
+  MacroExpansionException(std::size_t exception_id,
+                        std::string message) :
+      shaka::BaseException(exception_id, message) {}
+};
+
+}
+#endif //SHAKA_SCHEME_MACROEXPANSIONEXCEPTION_HPP

--- a/src/shaka_scheme/system/parser/parser_definitions.hpp
+++ b/src/shaka_scheme/system/parser/parser_definitions.hpp
@@ -179,6 +179,19 @@ ParserRule parse_datum = [&](ParserInput& in) -> ParserResult {
     }
   }
 
+  if (in.peek().token_type == "quote") {
+    auto saved_token = in.get();
+    auto parsed_datum = parse_datum(in);
+    if (!parsed_datum.is_complete()) {
+      in.unget(saved_token);
+      return parsed_datum;
+    } else {
+      return Complete(core::list(
+          create_node(Symbol("quote")),
+          parsed_datum.it));
+    }
+  }
+
   auto simple_datum = parse_simple(in);
   if (simple_datum.is_complete()) {
     return simple_datum;

--- a/src/shaka_scheme/system/parser/parser_definitions.hpp
+++ b/src/shaka_scheme/system/parser/parser_definitions.hpp
@@ -131,18 +131,24 @@ auto parse_simple = [](ParserInput& in) {
 
 ParserRule parse_datum = [&](ParserInput& in) -> ParserResult {
   auto parse_list = [&](ParserInput& in) {
-    std::cout << "parse-list" << std::endl;
+    //std::cout << "parse-list" << std::endl;
     auto data_list = core::list();
+    //std::cout << "TOKEN: " << in.peek() << std::endl;
     if (in.peek().token_type == "paren-left") {
       in.get();
     }
     while (in.peek().token_type != "paren-right") {
+      //std::cout << "TOKEN: " << in.peek() << std::endl;
       ParserResult datum_result = parse_datum(in);
+      //std::cout << "DATUM:" << datum_result << std::endl;
       if (datum_result.is_complete()) {
         data_list = core::append(data_list, core::list(datum_result.it));
       } else if (in.peek().token_type == "dot") {
         in.get();
+        //std::cout << "in.peek(): " << in.peek() << std::endl;
         datum_result = parse_datum(in);
+        //std::cout << "IMPROPER LIST LAST DATUM: " << datum_result <<
+        // std::endl;
         if (datum_result.is_complete()) {
           data_list = core::append(data_list, datum_result.it);
         } else {
@@ -180,6 +186,8 @@ ParserRule parse_datum = [&](ParserInput& in) -> ParserResult {
     auto next = in.peek();
     if (next.token_type == "paren-left") {
       return parse_list(in);
+    } else {
+      return ParserError(next, "could not parse non-simple datum");
     }
   }
 

--- a/src/shaka_scheme/system/parser/syntax_rules/MacroContext.cpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/MacroContext.cpp
@@ -1,0 +1,58 @@
+#include "shaka_scheme/system/parser/syntax_rules/MacroContext.hpp"
+
+namespace shaka {
+namespace macro {
+
+std::ostream& operator<<(std::ostream& left, const ScopeSet& right) {
+  left << "ScopeMap({ ";
+  for (auto it : right) {
+    left << it << " ";
+  }
+  left << "})";
+  return left;
+}
+
+MacroContext::MacroContext(HeapVirtualMachine& hvm) :
+    hvm(hvm),
+    curr_scope(0) {
+  curr_scopes.insert(curr_scope);
+  curr_scope_stack.push_back(curr_scope);
+  curr_scope = next_scope;
+  next_scope++;
+  curr_scopes.insert(curr_scope);
+  curr_scope_stack.push_back(curr_scope);
+}
+
+void MacroContext::push_scope() {
+  curr_scope = next_scope;
+  next_scope++;
+  curr_scopes.insert(curr_scope);
+  curr_scope_stack.push_back(curr_scope);
+}
+
+void MacroContext::pop_scope() {
+  curr_scopes.erase(curr_scope);
+  auto temp_scope = curr_scope_stack[curr_scope_stack.size() - 1];
+  curr_scope_stack.pop_back();
+  curr_scope = temp_scope;
+}
+
+void MacroContext::map_symbol(Symbol symbol) {
+  IdentifierData id_data(curr_scopes, nullptr);
+  identifier_bindings.insert({ symbol, std::move(id_data)});
+}
+
+void MacroContext::map_macro(Symbol symbol, MacroPtr macro) {
+  IdentifierData id_data(curr_scopes, std::move(macro));
+  identifier_bindings.insert({ symbol, std::move(id_data) });
+}
+
+std::multimap<shaka::Symbol, IdentifierData>::const_iterator
+MacroContext::get_bindings(Symbol symbol) {
+  return identifier_bindings.find(symbol);
+}
+
+
+
+} // namespace macro
+} // namespace shaka

--- a/src/shaka_scheme/system/parser/syntax_rules/MacroContext.hpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/MacroContext.hpp
@@ -1,0 +1,152 @@
+#ifndef SHAKA_SCHEME_MACROCONTEXT_HPP
+#define SHAKA_SCHEME_MACROCONTEXT_HPP
+
+#include "shaka_scheme/system/parser/parser_definitions.hpp"
+#include "shaka_scheme/system/core/lists.hpp"
+#include "shaka_scheme/system/core/types.hpp"
+
+#include "shaka_scheme/system/exceptions/MacroExpansionException.hpp"
+#include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
+#include "shaka_scheme/system/parser/syntax_rules/SyntaxRulesMacro.hpp"
+
+#include <map>
+#include <stack>
+#include <algorithm>
+#include <set>
+
+namespace shaka {
+namespace macro {
+
+/**
+ * @brief The alias for the set of scopes that we use for lexical analysis.
+ */
+using ScopeSet = std::set<std::size_t>;
+
+/**
+ * @brief Used to print out the scopes for debugging purposes.
+ * @param left The output stream to output to.
+ * @param right The ScopeSet to print out
+ * @return The updated reference to the output stream.
+ */
+std::ostream& operator<<(std::ostream& left, const ScopeSet& right);
+
+/**
+ * @brief The type of a macro that will be used in macro expansion.
+ */
+class SyntaxRulesMacro;
+
+/**
+ * @brief The type of data stored in the identifier bindings.
+ */
+struct IdentifierData {
+  /**
+   * @brief Initializes the struct with a set of scopes and an optional macro.
+   * @param scopes The set of lexical scopes.
+   * @param macro A shared pointer to an optional macro. If it is not
+   * present, this identifier binding does not bind to a macro.
+   */
+  IdentifierData(ScopeSet scopes, MacroPtr macro = nullptr) :
+      scopes(scopes),
+      macro(std::move(macro)) {}
+
+  ScopeSet scopes;
+  MacroPtr macro;
+};
+
+/**
+ * @brief The interface for managing lexical information at macro expansion
+ * time.
+ */
+struct MacroContext {
+
+  /**
+   * @brief Intializes the MacroContext with the 0th scope and the 1st scope.
+   * @param hvm The HeapVirtualMachien to query for the presence of primitive
+   * forms.
+   */
+  MacroContext(HeapVirtualMachine& hvm);
+
+  /**
+   * @brief Changes the internal state of the context to have one additional
+   * scope in its internal scope stack.
+   */
+  void push_scope();
+
+  /**
+   * @brief Pops the most recent scope from the current tracking set of scopes,
+   * and restores the most recent one to the curr_scope variable.
+   */
+  void pop_scope();
+
+  /**
+   * @brief Maps an identifier to a non-macro binding.
+   * @param symbol The symbol to bind with the current set of scopes.
+   */
+  void map_symbol(Symbol symbol);
+
+  /**
+   * @brief Maps an identifier to a macro.
+   * @param symbol The symbol to bind to the macro.
+   * @param macro The macro to be bound inside the macro expansion identifier
+   * bindings map.
+   */
+  void map_macro(Symbol symbol, MacroPtr macro);
+
+  /**
+   * @brief Gets an iterator to a list of bindings that share the same
+   * symbol, but not necesarily the same sets of scopes.
+   * @param symbol The symbol to query for in the identifier bindings.
+   * @return A constant iterator to a list of bindings.
+   */
+  std::multimap<shaka::Symbol, IdentifierData>::const_iterator
+  get_bindings(Symbol symbol);
+
+  /**
+   * @brief A reference to the virtual machine to use when deciding the
+   * presence of primitive forms.
+   */
+  HeapVirtualMachine& hvm;
+
+  /**
+   * @brief Stores the order that the context goes into scopes so it can
+   * restore the most recent one.
+   */
+  std::vector<std::size_t> curr_scope_stack;
+
+  /**
+   * @brief The current set of scopes to use when binding identifiers in this
+   * immediate scope.
+   */
+  ScopeSet curr_scopes;
+
+  /**
+   * @brief Stores the current scope index. Defaults to 0.
+   */
+  std::size_t curr_scope = 0;
+
+  /**
+   * @brief Stores the next scope. Defeaults to curr_scope + 1.
+   */
+  std::size_t next_scope = 1;
+
+  /**
+   * @brief The identifier bindings table, which can store multiple
+   * identifiers with possible different sets of scopes.
+   */
+  std::multimap<shaka::Symbol, IdentifierData> identifier_bindings;
+
+  /**
+   * @brief Prints out a short representation of the MacroContext.
+   * @param lhs The output stream.
+   * @param rhs The MacroContext.
+   * @return The updated reference of the output stream.
+   */
+  friend std::ostream& operator<<(
+      std::ostream& lhs,
+      const MacroContext& rhs);
+};
+
+} // namespace macro
+} // namespace shaka
+
+#endif //SHAKA_SCHEME_MACROCONTEXT_HPP

--- a/src/shaka_scheme/system/parser/syntax_rules/SyntaxRulesMacro.cpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/SyntaxRulesMacro.cpp
@@ -1,0 +1,1 @@
+#include "shaka_scheme/system/parser/syntax_rules/SyntaxRulesMacro.hpp"

--- a/src/shaka_scheme/system/parser/syntax_rules/SyntaxRulesMacro.hpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/SyntaxRulesMacro.hpp
@@ -1,0 +1,29 @@
+#ifndef SHAKA_SCHEME_SYNTAXRULESMACRO_HPP
+#define SHAKA_SCHEME_SYNTAXRULESMACRO_HPP
+
+#include <memory>
+
+namespace shaka {
+namespace macro {
+
+/**
+ * @brief The type of a syntax-rules macro.
+ *
+ * It stores its pattern-matching and substitution functionality.
+ *
+ * This type is meant to operator on Scheme lists with an additional
+ * MacroChecker context -- unlike R6RS, syntax objects are not directly needed
+ * to support R7RS.
+ */
+class SyntaxRulesMacro {
+};
+
+/**
+ * @brief The alias for the macro pointer type.
+ */
+using MacroPtr = std::shared_ptr<SyntaxRulesMacro>;
+
+} // namespace macro
+} // namespace shaka
+
+#endif //SHAKA_SCHEME_SYNTAXRULESMACRO_HPP

--- a/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
@@ -1,0 +1,254 @@
+//
+// Created by aytas on 11/8/2017.
+//
+
+#ifndef SHAKA_SCHEME_MACRO_ENGINE_HPP
+#define SHAKA_SCHEME_MACRO_ENGINE_HPP
+
+#include "shaka_scheme/system/parser/parser_definitions.hpp"
+#include "shaka_scheme/system/core/lists.hpp"
+#include "shaka_scheme/system/core/types.hpp"
+
+#include <map>
+#include <stack>
+#include <algorithm>
+
+namespace shaka {
+namespace macro {
+
+template<typename T>
+struct TreeNode {
+
+  TreeNode(const T& data, std::shared_ptr<TreeNode<T>> parent = nullptr) :
+      data(data),
+      parent(parent) {}
+
+  TreeNode(const TreeNode& other) = delete;
+
+  TreeNode(TreeNode&& other) :
+      data(std::move(other.data)),
+      children(std::move(other.children)),
+      parent(std::move(other.parent)) {}
+
+  T data;
+  std::vector<std::shared_ptr<TreeNode>> children;
+  std::weak_ptr<TreeNode> parent;
+};
+
+using ScopeMap = std::map<shaka::Symbol, std::set<std::size_t>>;
+struct ScopeData {
+  std::size_t scope_id;
+  ScopeMap scopes;
+};
+
+std::ostream& operator<<(std::ostream& left, const std::set<std::size_t>&
+right) {
+  left << "ScopeMap({ ";
+  for (auto it : right) {
+
+    left << it << " ";
+  }
+  left << "})";
+  return left;
+}
+
+using ScopeTree = TreeNode<ScopeData>;
+using ScopePtr = std::shared_ptr<ScopeTree>;
+
+using ScopeSet = std::set<std::size_t>;
+
+struct SyntaxRulesMacro;
+using MacroPtr = std::shared_ptr<SyntaxRulesMacro>;
+
+struct SyntaxRulesMacro {
+
+};
+
+struct IdentifierData {
+  IdentifierData(ScopeSet scopes, MacroPtr macro = nullptr) :
+      scopes(scopes),
+      macro(std::move(macro)) {}
+
+  ScopeSet scopes;
+  MacroPtr macro;
+};
+
+struct MacroContextChecker {
+
+  MacroContextChecker(HeapVirtualMachine& hvm) :
+      curr_scope(0),
+      hvm(hvm) {
+    curr_scopes.insert(curr_scope);
+    curr_scope_stack.push_back(curr_scope);
+    ++curr_scope;
+    curr_scopes.insert(curr_scope);
+    curr_scope_stack.push_back(curr_scope);
+  }
+
+  void push_scope() {
+    ++curr_scope;
+    curr_scopes.insert(curr_scope);
+    curr_scope_stack.push_back(curr_scope);
+  }
+
+  void pop_scope() {
+    curr_scopes.erase(curr_scope);
+    auto temp_scope = curr_scope_stack[curr_scope_stack.size() - 1];
+    curr_scope_stack.pop_back();
+    curr_scope = temp_scope;
+  }
+
+  void map_symbol(Symbol symbol) {
+    IdentifierData id_data (curr_scopes, nullptr);
+    identifier_bindings.insert({
+                                   symbol,
+                               std::move(id_data)});
+  }
+
+  void map_macro(Symbol symbol, MacroPtr macro) {
+    IdentifierData id_data (curr_scopes, std::move(macro));
+    identifier_bindings.insert({
+                                   symbol,
+                                   std::move(id_data)
+                               });
+  }
+
+  std::multimap<shaka::Symbol, IdentifierData>::const_iterator
+  get_bindings(Symbol symbol) {
+    return identifier_bindings.find(symbol);
+  }
+
+  HeapVirtualMachine& hvm;
+  std::vector<std::size_t> curr_scope_stack;
+  ScopeSet curr_scopes;
+  std::size_t curr_scope = 1;
+  std::multimap<shaka::Symbol, IdentifierData> identifier_bindings;
+
+  friend std::ostream& operator<<(
+      std::ostream& lhs,
+      const MacroContextChecker& rhs);
+};
+
+auto is_primitive_set = [](Symbol symbol, MacroContextChecker& context) {
+  try {
+    if (context.hvm.get_environment()->get_value(symbol)
+        ->get<PrimitiveFormMarker>() == PrimitiveFormMarker("set!")) {
+      return true;
+    }
+  } catch (shaka::InvalidInputException e) {
+    return false;
+  }
+  return false;
+};
+
+auto get_macro = [](Symbol symbol, MacroContextChecker& context) {
+  IdentifierData current_binding(context.curr_scopes, nullptr);
+  IdentifierData max_data(std::set<std::size_t>(), nullptr);
+  for (auto it = context.get_bindings(symbol);
+       it != context.identifier_bindings.end();
+       ++it) {
+    const auto scopes = it->second.scopes;
+    std::vector<std::size_t> intersect;
+    std::set_intersection(
+        scopes.begin(),
+        scopes.end(),
+        current_binding.scopes.begin(),
+        current_binding.scopes.end(),
+        std::back_inserter(intersect)
+    );
+    if (intersect.size() > max_data.scopes.size()) {
+      max_data = it->second;
+    }
+  }
+  return max_data.macro;
+};
+
+auto is_primitive_syntax_rules =
+    [](Symbol symbol, MacroContextChecker& context) {
+      try {
+        if (context.hvm.get_environment()->get_value(symbol)
+            ->get<PrimitiveFormMarker>()
+            == PrimitiveFormMarker("syntax-rules")) {
+          return true;
+        }
+      } catch (shaka::InvalidInputException e) {
+        return false;
+      }
+      return false;
+    };
+
+auto is_primitive_lambda = [](Symbol symbol, MacroContextChecker& context) {
+  try {
+    if (context.hvm.get_environment()->get_value(symbol)
+        ->get<PrimitiveFormMarker>() == PrimitiveFormMarker("lambda")) {
+      return true;
+    }
+  } catch (shaka::InvalidInputException e) {
+    return false;
+  }
+  return false;
+};
+
+auto is_primitive_quote = [](Symbol symbol, MacroContextChecker& context) {
+  try {
+    if (context.hvm.get_environment()->get_value(symbol)
+        ->get<PrimitiveFormMarker>() == PrimitiveFormMarker("quote")) {
+      return true;
+    }
+  } catch (shaka::InvalidInputException e) {
+    return false;
+  }
+  return false;
+};
+
+auto is_primitive_define_syntax =
+    [](Symbol symbol, MacroContextChecker& context) {
+      try {
+        if (context.hvm.get_environment()->get_value(symbol)
+            ->get<PrimitiveFormMarker>() ==
+            PrimitiveFormMarker("define-syntax")) {
+          return true;
+        }
+      } catch (shaka::InvalidInputException e) {
+        return false;
+      }
+      return false;
+    };
+
+auto is_primitive_let_syntax =
+    [](Symbol symbol, MacroContextChecker& context) {
+      try {
+        if (context.hvm.get_environment()->get_value(symbol)
+            ->get<PrimitiveFormMarker>() ==
+            PrimitiveFormMarker("let-syntax")) {
+          return true;
+        }
+      } catch (shaka::InvalidInputException e) {
+        return false;
+      }
+      return false;
+    };
+
+std::ostream& operator<<(
+    std::ostream& lhs,
+    const MacroContextChecker& rhs) {
+  lhs << "MacroContextChecker(";
+  lhs << "curr_scope: " << rhs.curr_scope << " | ";
+  lhs << "scope_stack: { ";
+  for (auto it : rhs.curr_scope_stack) {
+    lhs << it << " ";
+  }
+  lhs << "} | ";
+  lhs << "curr_scopes: { ";
+  for (auto it : rhs.curr_scopes) {
+    lhs << it << " ";
+  }
+  lhs << "}";
+  lhs << ")";
+  return lhs;
+}
+
+} // namespace macro
+} // namespace shaka
+
+#endif //SHAKA_SCHEME_MACRO_ENGINE_HPP

--- a/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
@@ -318,7 +318,7 @@ void run_macro_expansion(
     auto item = core::car(it);
     //std::cout << "#" << count << ": " << *it << " | " << *item << std::endl;
     if (core::is_proper_list(item)) {
-      traverse_tree(item, macro_context);
+      run_macro_expansion(item, macro_context);
     }
   }
   if (need_to_pop_scope) {

--- a/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
@@ -1,13 +1,13 @@
-//
-// Created by aytas on 11/8/2017.
-//
-
 #ifndef SHAKA_SCHEME_MACRO_ENGINE_HPP
 #define SHAKA_SCHEME_MACRO_ENGINE_HPP
 
 #include "shaka_scheme/system/parser/parser_definitions.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
 #include "shaka_scheme/system/core/types.hpp"
+
+#include "shaka_scheme/system/exceptions/MacroExpansionException.hpp"
+
+#include "shaka_scheme/system/parser/syntax_rules/MacroContext.hpp"
 
 #include <map>
 #include <stack>
@@ -16,120 +16,7 @@
 namespace shaka {
 namespace macro {
 
-template<typename T>
-struct TreeNode {
-
-  TreeNode(const T& data, std::shared_ptr<TreeNode<T>> parent = nullptr) :
-      data(data),
-      parent(parent) {}
-
-  TreeNode(const TreeNode& other) = delete;
-
-  TreeNode(TreeNode&& other) :
-      data(std::move(other.data)),
-      children(std::move(other.children)),
-      parent(std::move(other.parent)) {}
-
-  T data;
-  std::vector<std::shared_ptr<TreeNode>> children;
-  std::weak_ptr<TreeNode> parent;
-};
-
-using ScopeMap = std::map<shaka::Symbol, std::set<std::size_t>>;
-struct ScopeData {
-  std::size_t scope_id;
-  ScopeMap scopes;
-};
-
-std::ostream& operator<<(std::ostream& left, const std::set<std::size_t>&
-right) {
-  left << "ScopeMap({ ";
-  for (auto it : right) {
-
-    left << it << " ";
-  }
-  left << "})";
-  return left;
-}
-
-using ScopeTree = TreeNode<ScopeData>;
-using ScopePtr = std::shared_ptr<ScopeTree>;
-
-using ScopeSet = std::set<std::size_t>;
-
-struct SyntaxRulesMacro;
-using MacroPtr = std::shared_ptr<SyntaxRulesMacro>;
-
-struct SyntaxRulesMacro {
-
-};
-
-struct IdentifierData {
-  IdentifierData(ScopeSet scopes, MacroPtr macro = nullptr) :
-      scopes(scopes),
-      macro(std::move(macro)) {}
-
-  ScopeSet scopes;
-  MacroPtr macro;
-};
-
-struct MacroContextChecker {
-
-  MacroContextChecker(HeapVirtualMachine& hvm) :
-      curr_scope(0),
-      hvm(hvm) {
-    curr_scopes.insert(curr_scope);
-    curr_scope_stack.push_back(curr_scope);
-    ++curr_scope;
-    curr_scopes.insert(curr_scope);
-    curr_scope_stack.push_back(curr_scope);
-  }
-
-  void push_scope() {
-    ++curr_scope;
-    curr_scopes.insert(curr_scope);
-    curr_scope_stack.push_back(curr_scope);
-  }
-
-  void pop_scope() {
-    curr_scopes.erase(curr_scope);
-    auto temp_scope = curr_scope_stack[curr_scope_stack.size() - 1];
-    curr_scope_stack.pop_back();
-    curr_scope = temp_scope;
-  }
-
-  void map_symbol(Symbol symbol) {
-    IdentifierData id_data (curr_scopes, nullptr);
-    identifier_bindings.insert({
-                                   symbol,
-                               std::move(id_data)});
-  }
-
-  void map_macro(Symbol symbol, MacroPtr macro) {
-    IdentifierData id_data (curr_scopes, std::move(macro));
-    identifier_bindings.insert({
-                                   symbol,
-                                   std::move(id_data)
-                               });
-  }
-
-  std::multimap<shaka::Symbol, IdentifierData>::const_iterator
-  get_bindings(Symbol symbol) {
-    return identifier_bindings.find(symbol);
-  }
-
-  HeapVirtualMachine& hvm;
-  std::vector<std::size_t> curr_scope_stack;
-  ScopeSet curr_scopes;
-  std::size_t curr_scope = 1;
-  std::multimap<shaka::Symbol, IdentifierData> identifier_bindings;
-
-  friend std::ostream& operator<<(
-      std::ostream& lhs,
-      const MacroContextChecker& rhs);
-};
-
-auto is_primitive_set = [](Symbol symbol, MacroContextChecker& context) {
+bool is_primitive_set(Symbol symbol, MacroContext& context) {
   try {
     if (context.hvm.get_environment()->get_value(symbol)
         ->get<PrimitiveFormMarker>() == PrimitiveFormMarker("set!")) {
@@ -141,7 +28,7 @@ auto is_primitive_set = [](Symbol symbol, MacroContextChecker& context) {
   return false;
 };
 
-auto get_macro = [](Symbol symbol, MacroContextChecker& context) {
+MacroPtr get_macro(Symbol symbol, MacroContext& context) {
   IdentifierData current_binding(context.curr_scopes, nullptr);
   IdentifierData max_data(std::set<std::size_t>(), nullptr);
   for (auto it = context.get_bindings(symbol);
@@ -163,21 +50,20 @@ auto get_macro = [](Symbol symbol, MacroContextChecker& context) {
   return max_data.macro;
 };
 
-auto is_primitive_syntax_rules =
-    [](Symbol symbol, MacroContextChecker& context) {
-      try {
-        if (context.hvm.get_environment()->get_value(symbol)
-            ->get<PrimitiveFormMarker>()
-            == PrimitiveFormMarker("syntax-rules")) {
-          return true;
-        }
-      } catch (shaka::InvalidInputException e) {
-        return false;
-      }
-      return false;
-    };
+bool is_primitive_syntax_rules(Symbol symbol, MacroContext& context) {
+  try {
+    if (context.hvm.get_environment()->get_value(symbol)
+        ->get<PrimitiveFormMarker>()
+        == PrimitiveFormMarker("syntax-rules")) {
+      return true;
+    }
+  } catch (shaka::InvalidInputException e) {
+    return false;
+  }
+  return false;
+};
 
-auto is_primitive_lambda = [](Symbol symbol, MacroContextChecker& context) {
+bool is_primitive_lambda(Symbol symbol, MacroContext& context) {
   try {
     if (context.hvm.get_environment()->get_value(symbol)
         ->get<PrimitiveFormMarker>() == PrimitiveFormMarker("lambda")) {
@@ -189,7 +75,19 @@ auto is_primitive_lambda = [](Symbol symbol, MacroContextChecker& context) {
   return false;
 };
 
-auto is_primitive_quote = [](Symbol symbol, MacroContextChecker& context) {
+bool is_primitive_define(Symbol symbol, MacroContext& context) {
+  try {
+    if (context.hvm.get_environment()->get_value(symbol)
+        ->get<PrimitiveFormMarker>() == PrimitiveFormMarker("define")) {
+      return true;
+    }
+  } catch (shaka::InvalidInputException e) {
+    return false;
+  }
+  return false;
+};
+
+bool is_primitive_quote(Symbol symbol, MacroContext& context) {
   try {
     if (context.hvm.get_environment()->get_value(symbol)
         ->get<PrimitiveFormMarker>() == PrimitiveFormMarker("quote")) {
@@ -201,51 +99,239 @@ auto is_primitive_quote = [](Symbol symbol, MacroContextChecker& context) {
   return false;
 };
 
-auto is_primitive_define_syntax =
-    [](Symbol symbol, MacroContextChecker& context) {
-      try {
-        if (context.hvm.get_environment()->get_value(symbol)
-            ->get<PrimitiveFormMarker>() ==
-            PrimitiveFormMarker("define-syntax")) {
-          return true;
-        }
-      } catch (shaka::InvalidInputException e) {
-        return false;
-      }
-      return false;
-    };
+bool is_primitive_define_syntax(Symbol symbol, MacroContext& context) {
+  try {
+    if (context.hvm.get_environment()->get_value(symbol)
+        ->get<PrimitiveFormMarker>() ==
+        PrimitiveFormMarker("define-syntax")) {
+      return true;
+    }
+  } catch (shaka::InvalidInputException e) {
+    return false;
+  }
+  return false;
+};
 
-auto is_primitive_let_syntax =
-    [](Symbol symbol, MacroContextChecker& context) {
-      try {
-        if (context.hvm.get_environment()->get_value(symbol)
-            ->get<PrimitiveFormMarker>() ==
-            PrimitiveFormMarker("let-syntax")) {
-          return true;
-        }
-      } catch (shaka::InvalidInputException e) {
-        return false;
+bool is_primitive_let_syntax(Symbol symbol, MacroContext& context) {
+  try {
+    if (context.hvm.get_environment()->get_value(symbol)
+        ->get<PrimitiveFormMarker>() ==
+        PrimitiveFormMarker("let-syntax")) {
+      return true;
+    }
+  } catch (shaka::InvalidInputException e) {
+    return false;
+  }
+  return false;
+};
+
+bool process_define_form(NodePtr& it, MacroContext& context) {
+  if (!is_primitive_define(core::car(it)->get<Symbol>(), context)) {
+    return false;
+  }
+  using namespace shaka::core;
+  if (is_proper_list(car(cdr(it))) || is_improper_list(car(cdr(it)))) {
+    auto lambda_form = list(
+        create_node(Symbol("lambda")),
+        cdr(car(cdr(it)))
+    );
+    set_cdr(cdr(lambda_form), cdr(cdr(it)));
+    auto rewritten_form = list(
+        create_node(Symbol("define")),
+        car(car(cdr(it))),
+        lambda_form
+    );
+    it = rewritten_form;
+    //std::cout << "DEFINE: rewriting define procedure form: " << *it <<
+    //          std::endl;
+    return process_define_form(it, context);
+  }
+  if (is_symbol(car(cdr(it)))) {
+    //std::cout << "mapping identifier: " << car(cdr(it))
+    //    ->get<Symbol>() << std::endl;
+    context.map_symbol(car(cdr(it))->get<Symbol>());
+
+    it = core::cdr(it);
+    it = core::cdr(it);
+    return true;
+  }
+};
+
+bool process_set_form(NodePtr& it, MacroContext& context) {
+  if (!is_primitive_set(core::car(it)->get<Symbol>(), context)) {
+    return false;
+  }
+  if (!core::is_symbol(core::car(core::cdr(it)))) {
+    throw MacroExpansionException(60007, "(set!) must have an identifier "
+        "as its second argument");
+  }
+  if (core::length(it) != 3) {
+    throw MacroExpansionException(60008, "(set!) expression must be a "
+        "list of 3 elements");
+  }
+  it = core::cdr(it);
+  it = core::cdr(it);
+  return true;
+};
+
+bool process_quote_form(NodePtr& it, MacroContext& context) {
+  if (!is_primitive_quote(core::car(it)->get<Symbol>(), context)) {
+    return false;
+  }
+  if (core::length(it) != 2) {
+    throw MacroExpansionException(60004, "(quote) cannot have more than 1 "
+        "argument");
+  }
+  it = core::cdr(it);
+  return true;
+};
+
+bool process_lambda_form(NodePtr& it, MacroContext& context) {
+  if (!is_primitive_lambda(core::car(it)->get<Symbol>(), context)) {
+    return false;
+  }
+  if (core::length(it) <= 2) {
+    throw MacroExpansionException(60001, "(lambda) form must contain at "
+        "least the arguments and the body expression(s)");
+  }
+  auto args = core::car(core::cdr(it));
+  std::vector<Symbol> identifiers;
+  // If the lambda is a proper or improper list, we must figure out
+  // if it consists of only identifiers.
+  if (core::is_pair(args)) {
+    auto jt = args;
+    //std::cout << "jt: " << *jt << std::endl;
+    for (;
+        core::is_pair(jt);
+        jt = core::cdr(jt)) {
+      auto item = core::car(jt);
+      //std::cout << "item: " << *item << std::endl;
+      if (item->get_type() != Data::Type::SYMBOL) {
+        throw MacroExpansionException(60000, "(lambda) arguments must "
+            "contain only identifiers");
       }
-      return false;
-    };
+      identifiers.push_back(item->get<Symbol>());
+    }
+    if (jt->get_type() == Data::Type::SYMBOL) {
+      //std::cout << "(lambda) improper list last args: " <<
+      //
+      // jt/->get<Symbol>()
+      //          << std::endl;
+      identifiers.push_back(jt->get<Symbol>());
+    } else if (jt->get_type() != Data::Type::NULL_LIST) {
+      //std::cout << *jt << std::endl;
+      throw MacroExpansionException(60006, "the last argument in a "
+          "(lambda) arguments list must be a symbol or a null list");
+    }
+    // If we got through the loop, we need to mark the identifiers with
+    // the current scope before we return true;
+    it = core::cdr(it);
+    it = core::cdr(it);
+    context.push_scope();
+    for (auto identifier : identifiers) {
+      //std::cout << "mapping identifier: " << identifier << std::endl;
+      context.map_symbol(identifier);
+    }
+    // The iterator is left at the body.
+    return true;
+  } else if (core::is_symbol(args)) {
+    //std::cout << "mapping identifier: " << *args << std::endl;
+    context.map_symbol(args->get<Symbol>());
+    it = core::cdr(it);
+    it = core::cdr(it);
+    return true;
+  } else {
+    throw MacroExpansionException(60002, "(lambda) arguments cannot be "
+        "non-symbol types");
+  }
+};
 
 std::ostream& operator<<(
     std::ostream& lhs,
-    const MacroContextChecker& rhs) {
-  lhs << "MacroContextChecker(";
-  lhs << "curr_scope: " << rhs.curr_scope << " | ";
-  lhs << "scope_stack: { ";
+    const MacroContext& rhs) {
+  lhs << "MacroContext(curr_scope: " << rhs.curr_scope << " | scope_stack: { ";
   for (auto it : rhs.curr_scope_stack) {
     lhs << it << " ";
   }
-  lhs << "} | ";
-  lhs << "curr_scopes: { ";
+  lhs << "} | curr_scopes: { ";
   for (auto it : rhs.curr_scopes) {
     lhs << it << " ";
   }
-  lhs << "}";
-  lhs << ")";
+  lhs << "})";
   return lhs;
+}
+
+void run_macro_expansion(
+    NodePtr root,
+    MacroContext& macro_context) {
+  //std::cout << "\nBEFORE TRAVERSE TREE: " << *root << std::endl;
+  //std::cout << "BEFORE TRAVERSE TREE CONTEXT: " << macro_context << std::endl;
+  //for (
+  //  auto binding :
+  //    macro_context.identifier_bindings) {
+  //  //std::cout << "BEFORE TRAVERSE TREE BINDINGS {" << binding.first << " | "
+  //  //    "" << binding .second.scopes << std::endl;
+  //}
+  int count = 0;
+  bool need_to_pop_scope = false;
+  if (core::is_pair(root)) {
+    NodePtr proc_name = core::car(root);
+    if (core::is_symbol(proc_name)) {
+      Symbol identifier = proc_name->get<Symbol>();
+      if (auto macro = get_macro(identifier, macro_context)) {
+        //std::cout << "NEED TO EXPAND MACRO HERE!" << std::endl;
+      } else {
+        if (process_define_form(root, macro_context)) {
+          //std::cout << "PRIMITIVE: define" << std::endl;
+        } else if (process_set_form(root, macro_context)) {
+          //std::cout << "PRIMITIVE: set" << std::endl;
+        } else if (process_lambda_form(root, macro_context)) {
+          //std::cout << "PRIMITIVE: lambda" << std::endl;
+          need_to_pop_scope = true;
+        } else if (process_quote_form(root, macro_context)) {
+          //std::cout << "PRIMITIVE: quote" << std::endl;
+          return;
+        } else if (is_primitive_define_syntax(identifier, macro_context)) {
+          //std::cout << "PRIMITIVE: define-syntax" << std::endl;
+          need_to_pop_scope = true;
+          macro_context.push_scope();
+        } else if (is_primitive_let_syntax(identifier, macro_context)) {
+          //std::cout << "PRIMITIVE: let-syntax" << std::endl;
+          need_to_pop_scope = true;
+          macro_context.push_scope();
+        } else if (is_primitive_syntax_rules(identifier, macro_context)) {
+          //std::cout << "PRIMITIVE: syntax-rules" << std::endl;
+          need_to_pop_scope = true;
+          macro_context.push_scope();
+        } else {
+          //std::cout << "NON-PRIMITIVE: " << *proc_name << std::endl;
+        }
+      }
+    } else if (!core::is_pair(proc_name)) {
+      throw MacroExpansionException(60010, "procedure name cannot be a "
+          "non-identifier or non-procedure call");
+    }
+  }
+  for (NodePtr it = root;
+       core::is_pair(it);
+       it = core::cdr(it), count++) {
+    auto item = core::car(it);
+    //std::cout << "#" << count << ": " << *it << " | " << *item << std::endl;
+    if (core::is_proper_list(item)) {
+      traverse_tree(item, macro_context);
+    }
+  }
+  if (need_to_pop_scope) {
+    macro_context.pop_scope();
+  }
+  //std::cout << "after TRAVERSE TREE: " << *root << std::endl;
+  //std::cout << "after TRAVERSE TREE CONTEXT: " << macro_context << std::endl;
+  //for (
+  //  auto binding :
+  //    macro_context.identifier_bindings) {
+  //  //std::cout << "after TRAVERSE TREE BINDINGS {" << binding.first << " | "
+  //  //    "" << binding .second.scopes << std::endl;
+  //} //std::cout << std::endl;
 }
 
 } // namespace macro

--- a/tst/shaka_scheme/system/parser/CMakeLists.txt
+++ b/tst/shaka_scheme/system/parser/CMakeLists.txt
@@ -1,2 +1,3 @@
 macro_shaka_scheme_test(unit-Parser)
+macro_shaka_scheme_test(unit-MacroContextChecker)
 

--- a/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
+++ b/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
@@ -1,0 +1,190 @@
+#include <gmock/gmock.h>
+
+#include "shaka_scheme/system/parser/parser_definitions.hpp"
+#include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
+#include "shaka_scheme/system/parser/syntax_rules/macro_engine.hpp"
+
+using namespace shaka::core;
+using namespace shaka::macro;
+using namespace shaka;
+
+
+TEST(MacroContextChecker, setup_vm) {
+  const auto& c = create_node;
+  NodePtr acc = create_node(Symbol("hi"));
+
+  NodePtr expr0 =
+      core::list(
+          c(Symbol("constant")),
+          c(PrimitiveFormMarker("set!")),
+          core::list(
+              c(Symbol("assign")),
+              c(Symbol("set!")),
+              core::list(c(Symbol("halt")))
+          )
+      );
+
+  NodePtr expr =
+      core::list(
+          c(Symbol("constant")),
+          c(PrimitiveFormMarker("lambda")),
+          core::list(
+              c(Symbol("assign")),
+              c(Symbol("lambda")),
+              expr0
+          )
+      );
+
+  std::cout << *expr << std::endl;
+
+  EnvPtr env = std::make_shared<Environment>(nullptr);
+  std::deque<NodePtr> value_rib;
+  std::shared_ptr<CallFrame> frame_ptr = std::make_shared<CallFrame>();
+
+  HeapVirtualMachine hvm(acc, expr, env, value_rib, nullptr);
+
+  hvm.evaluate_assembly_instruction();
+  std::cout << *hvm.get_expression() << std::endl;
+  hvm.evaluate_assembly_instruction();
+  std::cout << *hvm.get_expression() << std::endl;
+  hvm.evaluate_assembly_instruction();
+  std::cout << *hvm.get_expression() << std::endl;
+  hvm.evaluate_assembly_instruction();
+  std::cout << *hvm.get_expression() << std::endl;
+
+  for (auto it : hvm.get_environment()->get_bindings()) {
+    std::cout << it.first << " :: " << *it.second << std::endl;
+  }
+}
+
+/**
+ * @brief Test: mock define expression
+ */
+TEST(MacroContextChecker, other) {
+  using namespace shaka::parser;
+  using namespace shaka;
+  // Given: an input string
+  std::string buf = "(lambda (x) (+ x z) (lambda (y) (- y a)) (lambda (q) a))";
+
+  // Given: a ParserInput loaded with the input string.
+  parser::ParserInput input(buf);
+
+  // Given: the results will end up in this results vector.
+  auto result = parser::parse_datum(input);
+
+  HeapVirtualMachine hvm(
+      create_node(String("hello world")),
+      core::list(create_node(Symbol("halt"))),
+      std::make_shared<Environment>(nullptr),
+      ValueRib(),
+      nullptr
+  );
+
+  EnvPtr env = hvm.get_environment();
+
+  env->set_value(Symbol("set!"), create_node(PrimitiveFormMarker("set!")));
+  env->set_value(Symbol("lambda"), create_node(PrimitiveFormMarker("lambda")));
+  env->set_value(Symbol("quote"), create_node(PrimitiveFormMarker("quote")));
+  env->set_value(Symbol("define-syntax"),
+                 create_node(PrimitiveFormMarker("define-syntax")));
+  env->set_value(Symbol("let-syntax"),
+                 create_node(PrimitiveFormMarker("let-syntax")));
+  env->set_value(Symbol("syntax-rules"),
+                 create_node(PrimitiveFormMarker("syntax-rules")));
+
+  ASSERT_EQ(PrimitiveFormMarker("set!"),
+            env->get_value(Symbol("set!"))->get<PrimitiveFormMarker>());
+  ASSERT_EQ(PrimitiveFormMarker("lambda"),
+            env->get_value(Symbol("lambda"))->get<PrimitiveFormMarker>());
+  ASSERT_EQ(PrimitiveFormMarker("quote"),
+            env->get_value(Symbol("quote"))->get<PrimitiveFormMarker>());
+  ASSERT_EQ(PrimitiveFormMarker("define-syntax"),
+            env->get_value(Symbol("define-syntax"))
+                ->get<PrimitiveFormMarker>());
+  ASSERT_EQ(PrimitiveFormMarker("let-syntax"),
+            env->get_value(Symbol("let-syntax"))->get<PrimitiveFormMarker>());
+  ASSERT_EQ(PrimitiveFormMarker("syntax-rules"),
+            env->get_value(Symbol("syntax-rules"))->get<PrimitiveFormMarker>());
+
+  // Given: an environment to hold bindings
+  MacroContextChecker context(hvm);
+  std::cout << context << std::endl;
+  std::cout << result << std::endl;
+
+  if (!result.it) {
+    std::cout << "result.it is not valid." << std::endl;
+  }
+
+  std::cout << *result.it << std::endl;
+
+  std::function<void(NodePtr, MacroContextChecker&)> traverse_tree;
+  traverse_tree = [&](
+      NodePtr root,
+      MacroContextChecker& macro_context) {
+    int count = 0;
+    bool need_to_pop_scope = false;
+    if (core::is_pair(root)) {
+      NodePtr it = core::car(root);
+      if (core::is_symbol(it)) {
+        Symbol identifier = it->get<Symbol>();
+        if (auto macro = get_macro(identifier, macro_context)) {
+          std::cout << "NEED TO EXPAND MACRO HERE!" << std::endl;
+        } else {
+          macro_context.map_symbol(identifier);
+          if (is_primitive_set(identifier, macro_context)) {
+            std::cout << "PRIMITIVE: set" << std::endl;
+          } else if (is_primitive_lambda(identifier, macro_context)) {
+            std::cout << "PRIMITIVE: lambda" << std::endl;
+            need_to_pop_scope = true;
+            macro_context.push_scope();
+          } else if (is_primitive_quote(identifier, macro_context)) {
+            std::cout << "PRIMITIVE: quote" << std::endl;
+            return;
+          } else if (is_primitive_define_syntax(identifier, macro_context)) {
+            std::cout << "PRIMITIVE: define-syntax" << std::endl;
+            need_to_pop_scope = true;
+            macro_context.push_scope();
+          } else if (is_primitive_let_syntax(identifier, macro_context)) {
+            std::cout << "PRIMITIVE: let-syntax" << std::endl;
+            need_to_pop_scope = true;
+            macro_context.push_scope();
+          } else if (is_primitive_syntax_rules(identifier, macro_context)) {
+            std::cout << "PRIMITIVE: syntax-rules" << std::endl;
+            need_to_pop_scope = true;
+            macro_context.push_scope();
+          } else {
+            std::cout << "NON-PRIMITIVE: " << *it << std::endl;
+          }
+        }
+      } else {
+        return;
+      }
+    }
+    for (NodePtr it = cdr(root);
+         core::is_pair(it);
+         it = cdr(it), count++) {
+      auto item = car(it);
+      if (core::is_proper_list(item)) {
+        traverse_tree(item, macro_context);
+      }
+      if (core::is_symbol(item)) {
+        macro_context.map_symbol(item->get<Symbol>());
+      }
+      std::cout << "#" << count << ": " << *it << " | " << *item << std::endl;
+    }
+    if (need_to_pop_scope) {
+      macro_context.pop_scope();
+    }
+  };
+  traverse_tree(result.it, context);
+
+  for (
+    auto binding :
+      context.identifier_bindings) {
+    std::cout << "{" << binding.first << " | " << binding.second.scopes <<
+              std::endl;
+  }
+
+// Given:
+}
+

--- a/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
+++ b/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
@@ -124,7 +124,7 @@ TEST(MacroContext, other) {
 
   std::cout << *result.it << std::endl;
 
-  traverse_tree(result.it, context);
+  run_macro_expansion(result.it, context);
 
   for (
     auto binding :


### PR DESCRIPTION
I've created `MacroContext` and `SyntaxRulesMacro` as classes to encapsulate the macro-expansion-time lexical information tracking and syntax-rules macro implementation, respectively.

Many of the actual functions used lies in `macro_engine.hpp`, though, so be aware.

The two classes and many of the functions have been manually tested, but not turned into unit tests.

I have tested the following:

- regular `define` forms
- lambda-like `define` forms
- `set!` forms
- `lambda` forms
- `quote` forms.

`let-syntax` and `define-syntax` forms are to be filled in once the SyntaxRulesMacro class and functionality is filled out in the future.

Note: the `(define (foo x y) ...)` form appears to be working correctly -- I have implemented some basic re-writing functionality for it, provided that `define` is put into the HeapVirtualMachine's environment as `PrimitiveFormMarker("define")`. This is new functionality.

**Please check to see that the functions provided are robust for correctly assembling the correct identifier bindings with their sets of scopes.**

**Please check that the only unit test case given is working correctly.** You may want to uncomment the many `std::cout` statements if you want to see debugging output.