### PR TITLE
Fixed nested_comment and parse_datum

### DIFF
--- a/src/shaka_scheme/system/lexer/rules/rule_comment.hpp
+++ b/src/shaka_scheme/system/lexer/rules/rule_comment.hpp
@@ -20,11 +20,15 @@ LexerRule nested_comment_right = make_terminal("|#", "nested-comment-right");
 LexerRule nested_comment_delimiter = nested_comment_left | nested_comment_right;
 LexerRule comment_text = (!nested_comment_delimiter + make_class([](char c) { return true; }, "non-nested-comment-delimiter")) / "comment-text";
 
-LexerRule nested_comment = [&](LexerInput& input) {
-    LexerRule comment_cont = (nested_comment + comment_text);
-    return ((nested_comment_left + *comment_text +
-        *comment_cont +
-        nested_comment_right) / "nested-comment")(input);
+LexerRule nested_comment = [](LexerInput& input) {
+  LexerRule recurse;
+  recurse = [&](LexerInput& input) {
+      LexerRule comment_cont = (recurse + comment_text);
+      return ((nested_comment_left + *comment_text +
+          *comment_cont +
+          nested_comment_right) / "nested-comment")(input);
+  };
+  return recurse(input);
 };
 
 LexerRule comment = line_comment | nested_comment;


### PR DESCRIPTION
Hi all. The issue with the recursive lambda declarations for `parse_datum` and `nested_comment` has been resolved. The solution was surprisingly simple: just declare a nested lambda called `recurse` and have it refer to a lambda that has a `[&]` capture list. The internals of the outer lambda are simply nested inside of this inner lambda, and then we simply return the call to `recurse(in)` to the top level. All unit-Tests compile and pass with this fix.