### PR TITLE
Implemented basic REPL with arithmetic; other fixes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -119,6 +119,17 @@ int main() {
       shaka::Symbol("/"),
       create_node(div_numbers));
 
+  shaka::Closure display_datum(
+      top_level,
+      nullptr,
+      std::vector<shaka::Symbol>(0),
+      std::make_shared<shaka::Callable>(shaka::stdproc::display),
+      nullptr,
+      true);
+  top_level->set_value(
+      shaka::Symbol("display"),
+      create_node(display_datum));
+
   shaka::ValueRib vr;
 
   shaka::HeapVirtualMachine hvm(nullptr, nullptr, top_level, vr, nullptr);

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <limits> // for std::numeric_limits for std::cin.ignore()
 #include <vector>
+#include <shaka_scheme/runtime/stdproc/numbers_arithmetic.hpp>
 
 #include "shaka_scheme/system/exceptions/BaseException.hpp"
 #include "shaka_scheme/system/exceptions/TypeException.hpp"
@@ -10,6 +11,7 @@
 #include "shaka_scheme/system/lexer/rules/rule_token.hpp"
 #include "shaka_scheme/system/lexer/rules/init.hpp"
 #include "shaka_scheme/system/parser/parser_definitions.hpp"
+#include "shaka_scheme/system/parser/syntax_rules/macro_engine.hpp"
 
 int main() {
   // Given: the lexer rules are initialized
@@ -41,13 +43,81 @@ int main() {
 
   shaka::EnvPtr top_level = std::make_shared<shaka::Environment>(nullptr);
 
-  shaka::Closure string_append(top_level, nullptr,
-                               std::vector<shaka::Symbol>(0),
-  std::make_shared<shaka::Callable>(shaka::string_append), nullptr, true);
+  {
+    using namespace shaka;
 
+    top_level->set_value(Symbol("define"),
+                         create_node(PrimitiveFormMarker("define")));
+    top_level->set_value(
+        Symbol("set!"),
+        create_node(PrimitiveFormMarker("set!")));
+    top_level->set_value(Symbol("lambda"),
+                         create_node(PrimitiveFormMarker("lambda")));
+    top_level->set_value(
+        Symbol("quote"),
+        create_node(PrimitiveFormMarker("quote")));
+    top_level->set_value(Symbol("define-syntax"),
+                         create_node(PrimitiveFormMarker("define-syntax")));
+    top_level->set_value(Symbol("let-syntax"),
+                         create_node(PrimitiveFormMarker("let-syntax")));
+    top_level->set_value(Symbol("syntax-rules"),
+                         create_node(PrimitiveFormMarker("syntax-rules")));
+  }
 
-  top_level->set_value(shaka::Symbol("string-append"), create_node
-      (string_append));
+  shaka::Closure string_append(
+      top_level,
+      nullptr,
+      std::vector<shaka::Symbol>(0),
+      std::make_shared<shaka::Callable>(shaka::string_append),
+      nullptr,
+      true);
+  top_level->set_value(
+      shaka::Symbol("string-append"),
+      create_node(string_append));
+
+  shaka::Closure add_numbers(
+      top_level,
+      nullptr,
+      std::vector<shaka::Symbol>(0),
+      std::make_shared<shaka::Callable>(shaka::stdproc::add),
+      nullptr,
+      true);
+  top_level->set_value(
+      shaka::Symbol("+"),
+      create_node(add_numbers));
+
+  shaka::Closure sub_numbers(
+      top_level,
+      nullptr,
+      std::vector<shaka::Symbol>(0),
+      std::make_shared<shaka::Callable>(shaka::stdproc::sub),
+      nullptr,
+      true);
+  top_level->set_value(
+      shaka::Symbol("-"),
+      create_node(sub_numbers));
+
+  shaka::Closure mul_numbers(
+      top_level,
+      nullptr,
+      std::vector<shaka::Symbol>(0),
+      std::make_shared<shaka::Callable>(shaka::stdproc::mul),
+      nullptr,
+      true);
+  top_level->set_value(
+      shaka::Symbol("*"),
+      create_node(mul_numbers));
+
+  shaka::Closure div_numbers(
+      top_level,
+      nullptr,
+      std::vector<shaka::Symbol>(0),
+      std::make_shared<shaka::Callable>(shaka::stdproc::div),
+      nullptr,
+      true);
+  top_level->set_value(
+      shaka::Symbol("/"),
+      create_node(div_numbers));
 
   shaka::ValueRib vr;
 
@@ -60,29 +130,46 @@ int main() {
   auto halt_instruction = shaka::core::list(create_node(halt));
 
   while (!done) {
-    std::cout << "> " << std::flush;
     try {
+      std::cout << "> " << std::flush;
       getline(std::cin, buf);
       shaka::parser::ParserInput input(buf);
       auto result = shaka::parser::parse_datum(input);
+      //std::cout << "parsed datum" << std::endl;
+      if (result.is_lexer_error()) {
+        std::cout << "LexerError: " << result << std::endl;
+        input.tokens.clear();
+        input.lex.input.clear();
+        break;
+      } else if (result.is_parser_error()) {
+        std::cout << "ParserError: " << result << std::endl;
+        continue;
+      } else if (result.is_incomplete()) {
+        std::cout << "Incomplete: " << result << std::endl;
+        continue;
+      }
       shaka::Expression expr = result.it;
+      shaka::macro::MacroContext macro_context(hvm);
+      shaka::macro::run_macro_expansion(expr, macro_context);
+      //std::cout << "macro expanded datum" << std::endl;
       //std::cout << *expr << std::endl;
       shaka::Expression compiled = compiler.compile(expr, halt_instruction);
+      //std::cout << "compiled datum" << std::endl;
       //std::cout << *compiled << std::endl;
       hvm.set_expression(compiled);
       do {
-          hvm.evaluate_assembly_instruction();
-
+        hvm.evaluate_assembly_instruction();
       } while (shaka::core::car(hvm.get_expression())->get<shaka::Symbol>() !=
           shaka::Symbol("halt"));
       std::cout << *hvm.get_accumulator() << std::endl;
     } catch (shaka::InvalidInputException e) {
-      std::cerr << e.what() << std::endl;
-    } catch (shaka::TypeException *e) {
-      std::cerr << e->what() << std::endl;
+      std::cerr << "InvalidInputException: " << e.what() << std::endl;
+    } catch (shaka::TypeException e) {
+      std::cerr << "TypeException: " << e.what() << std::endl;
     }
     catch (std::runtime_error e) {
-      std::cerr << e.what() << std::endl;
+      std::cerr << "RuntimeError: " << e.what() << std::endl;
+      break;
     }
   }
 

--- a/src/shaka_scheme/runtime/stdproc/numbers_arithmetic.hpp
+++ b/src/shaka_scheme/runtime/stdproc/numbers_arithmetic.hpp
@@ -22,6 +22,12 @@ using Args = std::deque<NodePtr>;
 
 using Callable = std::function<std::deque<NodePtr>(std::deque<NodePtr>)>;
 namespace impl {
+
+Args display(Args args) {
+  std::cout << *args[0] << std::endl;
+  return Args{create_unspecified()};
+}
+
 // (+ z1 ...)
 Args add_numbers(Args args) {
 
@@ -781,6 +787,8 @@ Callable exp = impl::exp_numbers;
 Callable log = impl::log_numbers;
 Callable logn = impl::log_n_numbers;
 Callable sqrt = impl::sqrt_numbers;
+
+Callable display = impl::display;
 } // namespace stdproc
 } // namespace shaka
 

--- a/src/shaka_scheme/system/base/Data.cpp
+++ b/src/shaka_scheme/system/base/Data.cpp
@@ -114,7 +114,7 @@ shaka::Data::~Data() {
 template<>
 shaka::String& shaka::Data::get<shaka::String>() {
   if (this->get_type() != Type::STRING) {
-    throw new shaka::TypeException(3, "Could not get() String from Data");
+    throw shaka::TypeException(3, "Could not get() String from Data");
   }
   return this->string;
 }
@@ -122,7 +122,7 @@ shaka::String& shaka::Data::get<shaka::String>() {
 template<>
 shaka::Symbol& shaka::Data::get<shaka::Symbol>() {
   if (this->get_type() != Type::SYMBOL) {
-    throw new shaka::TypeException(4, "Could not get() Symbol from Data");
+    throw shaka::TypeException(4, "Could not get() Symbol from Data");
   }
   return this->symbol;
 }
@@ -130,7 +130,7 @@ shaka::Symbol& shaka::Data::get<shaka::Symbol>() {
 template<>
 shaka::Boolean& shaka::Data::get<shaka::Boolean>() {
   if (this->get_type() != Type::BOOLEAN) {
-    throw new shaka::TypeException(5, "Could not get() Boolean from Data");
+    throw shaka::TypeException(5, "Could not get() Boolean from Data");
   }
   return this->boolean;
 }
@@ -138,7 +138,7 @@ shaka::Boolean& shaka::Data::get<shaka::Boolean>() {
 template<>
 shaka::DataPair& shaka::Data::get<shaka::DataPair>() {
   if (this->get_type() != Type::DATA_PAIR) {
-    throw new shaka::TypeException(6, "Could not get() DataPair from Data");
+    throw shaka::TypeException(6, "Could not get() DataPair from Data");
   }
   return this->data_pair;
 }
@@ -146,7 +146,7 @@ shaka::DataPair& shaka::Data::get<shaka::DataPair>() {
 template<>
 shaka::Closure& shaka::Data::get<shaka::Closure>() {
   if (this->get_type() != Type::CLOSURE) {
-    throw new shaka::TypeException(7, "Could not get() Closure from Data");
+    throw shaka::TypeException(7, "Could not get() Closure from Data");
   }
   return this->closure;
 }
@@ -154,7 +154,7 @@ shaka::Closure& shaka::Data::get<shaka::Closure>() {
 template<>
 shaka::CallFrame& shaka::Data::get<shaka::CallFrame>() {
   if (this->get_type() != Type::CALL_FRAME) {
-    throw new shaka::TypeException(8, "Could not get() CallFrame from Data");
+    throw shaka::TypeException(8, "Could not get() CallFrame from Data");
   }
   return this->call_frame;
 }
@@ -162,7 +162,7 @@ shaka::CallFrame& shaka::Data::get<shaka::CallFrame>() {
 template<>
 shaka::PrimitiveFormMarker& shaka::Data::get<shaka::PrimitiveFormMarker>() {
   if (this->get_type() != Type::PRIMITIVE_FORM) {
-    throw new shaka::TypeException(9, "Could not get() PrimitiveFormMarker "
+    throw shaka::TypeException(9, "Could not get() PrimitiveFormMarker "
         "from Data");
   }
   return this->primitive_form;
@@ -171,7 +171,7 @@ shaka::PrimitiveFormMarker& shaka::Data::get<shaka::PrimitiveFormMarker>() {
 template<>
 shaka::Number& shaka::Data::get<shaka::Number>() {
   if (this->get_type() != Type::NUMBER) {
-    throw new shaka::TypeException(10, "Could not get() Number from Data");
+    throw shaka::TypeException(10, "Could not get() Number from Data");
   }
   return this->number;
 }

--- a/src/shaka_scheme/system/base/DataPair.cpp
+++ b/src/shaka_scheme/system/base/DataPair.cpp
@@ -7,7 +7,7 @@
 
 namespace shaka {
 
-NodePtr create_node(Data data) {
+NodePtr create_node(const Data& data) {
   return std::make_shared<Data>(data);
 }
 

--- a/src/shaka_scheme/system/base/DataPair.hpp
+++ b/src/shaka_scheme/system/base/DataPair.hpp
@@ -24,7 +24,7 @@ using NodePtr = std::shared_ptr<Data>;
  * or reference counting, we trust that all managed objects will either be
  * managed by user-supplied logic in this function, or through
  */
-NodePtr create_node(Data data);
+NodePtr create_node(const Data& data);
 
 /**
  * @brief The data representation of a Scheme pair.

--- a/src/shaka_scheme/system/base/Environment.cpp
+++ b/src/shaka_scheme/system/base/Environment.cpp
@@ -26,6 +26,17 @@ void Environment::set_value(const Key& key, Value data) {
   local[key] = data;
 }
 
+void Environment::modify_value(const Key& key, Value data) {
+  if (this->contains(key)) {
+    local[key] = data;
+  } else if (this->parent == nullptr) {
+    throw shaka::InvalidInputException(2001, "Environment.modify_value: key "
+        "does not exist in current environment or parent environments");
+  } else {
+    this->parent->modify_value(key, data);
+  }
+}
+
 Value Environment::get_value(const Key& key) {
 
   /* Check if the key exists in local */

--- a/src/shaka_scheme/system/base/Environment.hpp
+++ b/src/shaka_scheme/system/base/Environment.hpp
@@ -53,6 +53,14 @@ public:
   void set_value(const Key& key, Value data) override;
 
   /**
+   * @brief Sets an element in the Environment referred to by the 'key'
+   *        and sets its value to 'data'
+   * @param key They key to be used for lookup in the environment
+   * @param data The data associated with the key
+   */
+  void modify_value(const Key& key, Value data) override;
+
+  /**
    * @brief Returns a reference to the value referred to by the key. Key
    *        must exist, otherwise, it throws a runtime error.
    * @param key The key to lookup and return the value for.

--- a/src/shaka_scheme/system/base/IEnvironment.hpp
+++ b/src/shaka_scheme/system/base/IEnvironment.hpp
@@ -61,6 +61,12 @@ public:
   set_value(const Key& key,
             Value value) = 0;
 
+  /// @brief Modifies an element in the Environment referred to be the `key`
+  ///        and then sets its value to `value`.
+  virtual void
+  modify_value(const Key& key,
+               Value value) = 0;
+
   /// @brief Returns a list of all the keys in the Environment.
   virtual std::vector<Key>
   get_keys() = 0;

--- a/src/shaka_scheme/system/core/lists.hpp
+++ b/src/shaka_scheme/system/core/lists.hpp
@@ -180,6 +180,22 @@ inline NodePtr append(NodePtr first, NodePtr second, Args... rest) {
   return append(node, rest...);
 }
 
+inline NodePtr reverse_helper(const NodePtr left, const NodePtr right) {
+  return core::cons(right, left);
+}
+
+inline NodePtr reverse(NodePtr first) {
+  if (first->get_type() != shaka::Data::Type::DATA_PAIR) {
+    return create_node(*first);
+  }
+  if (core::is_null_list(core::cdr(first)))  {
+    return core::list(core::car(first));
+  } else {
+    return shaka::core::reverse_helper(core::car(first), reverse(core::cdr(first)));
+  }
+}
+
+
 } // namespace core
 } // namespace shaka
 

--- a/src/shaka_scheme/system/lexer/lexer_definitions.cpp
+++ b/src/shaka_scheme/system/lexer/lexer_definitions.cpp
@@ -60,7 +60,7 @@ LexResult Token(std::string str, LexInfo info, std::string token_type) {
 }
 
 LexResult Incomplete(std::string str, LexInfo info) {
-  return LexResult("incomplete", "", info);
+  return LexResult("incomplete", str, info);
 }
 
 std::ostream& operator<<(std::ostream& left, LexResult right) {
@@ -299,7 +299,7 @@ LexerRule alternative(LexerRule left,
     std::string buf;
 
     auto lresult = left(lex);
-    if (lresult.is_token() || lresult.is_incomplete()) {
+    if (lresult.is_token()) {
       return lresult;
     }
     auto rresult = right(lex);

--- a/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
@@ -213,7 +213,10 @@ bool process_lambda_form(NodePtr& it, MacroContext& context) {
   std::vector<Symbol> identifiers;
   // If the lambda is a proper or improper list, we must figure out
   // if it consists of only identifiers.
-  if (core::is_pair(args)) {
+  if (core::is_null_list(args)) {
+    context.push_scope();
+    return true;
+  } else if (core::is_pair(args)) {
     auto jt = args;
     //std::cout << "jt: " << *jt << std::endl;
     for (;

--- a/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
+++ b/src/shaka_scheme/system/parser/syntax_rules/macro_engine.hpp
@@ -24,6 +24,8 @@ bool is_primitive_set(Symbol symbol, MacroContext& context) {
     }
   } catch (shaka::InvalidInputException e) {
     return false;
+  } catch (shaka::TypeException e) {
+    return false;
   }
   return false;
 };
@@ -59,6 +61,8 @@ bool is_primitive_syntax_rules(Symbol symbol, MacroContext& context) {
     }
   } catch (shaka::InvalidInputException e) {
     return false;
+  } catch (shaka::TypeException e) {
+    return false;
   }
   return false;
 };
@@ -70,6 +74,8 @@ bool is_primitive_lambda(Symbol symbol, MacroContext& context) {
       return true;
     }
   } catch (shaka::InvalidInputException e) {
+    return false;
+  } catch (shaka::TypeException e) {
     return false;
   }
   return false;
@@ -83,6 +89,8 @@ bool is_primitive_define(Symbol symbol, MacroContext& context) {
     }
   } catch (shaka::InvalidInputException e) {
     return false;
+  } catch (shaka::TypeException e) {
+    return false;
   }
   return false;
 };
@@ -94,6 +102,8 @@ bool is_primitive_quote(Symbol symbol, MacroContext& context) {
       return true;
     }
   } catch (shaka::InvalidInputException e) {
+    return false;
+  } catch (shaka::TypeException e) {
     return false;
   }
   return false;
@@ -108,6 +118,8 @@ bool is_primitive_define_syntax(Symbol symbol, MacroContext& context) {
     }
   } catch (shaka::InvalidInputException e) {
     return false;
+  } catch (shaka::TypeException e) {
+    return false;
   }
   return false;
 };
@@ -121,6 +133,8 @@ bool is_primitive_let_syntax(Symbol symbol, MacroContext& context) {
     }
   } catch (shaka::InvalidInputException e) {
     return false;
+  } catch (shaka::TypeException e) {
+    return false;
   }
   return false;
 };
@@ -130,18 +144,19 @@ bool process_define_form(NodePtr& it, MacroContext& context) {
     return false;
   }
   using namespace shaka::core;
+  //std::cout << "cadr of it: " << *car(cdr(it)) << std::endl;
   if (is_proper_list(car(cdr(it))) || is_improper_list(car(cdr(it)))) {
+    //std::cout << "yes, needs to be lambda transformed" << std::endl;
     auto lambda_form = list(
         create_node(Symbol("lambda")),
         cdr(car(cdr(it)))
     );
     set_cdr(cdr(lambda_form), cdr(cdr(it)));
     auto rewritten_form = list(
-        create_node(Symbol("define")),
         car(car(cdr(it))),
         lambda_form
     );
-    it = rewritten_form;
+    set_cdr(it, rewritten_form);
     //std::cout << "DEFINE: rewriting define procedure form: " << *it <<
     //          std::endl;
     return process_define_form(it, context);

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -117,8 +117,8 @@ void HeapVirtualMachine::evaluate_assembly_instruction() {
     NodePtr then_exp = exp_cdr.car();
     NodePtr else_exp = exp_cdr.cdr()->get<DataPair>().car();
 
-    if (this->acc->get_type() == shaka::Data::Type::SYMBOL &&
-        this->acc->get<Symbol>() == Symbol("#f")) {
+    if (this->acc->get_type() == shaka::Data::Type::BOOLEAN &&
+        this->acc->get<Boolean>() == Boolean(false)) {
 
       this->set_expression(else_exp);
     }

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -130,8 +130,22 @@ void HeapVirtualMachine::evaluate_assembly_instruction() {
   }
 
   // (assign var x)
-
   if (instruction == shaka::Symbol("assign")) {
+    shaka::DataPair& exp_cdr = exp_pair.cdr()->get<DataPair>();
+    shaka::Symbol& var = exp_cdr.car()->get<Symbol>();
+
+    DataPair& next_pair = exp_cdr.cdr()->get<DataPair>();
+
+    NodePtr expression = next_pair.car();
+
+    this->env->modify_value(var, this->acc);
+
+    this->set_expression(expression);
+
+  }
+
+  // (define var x)
+  if (instruction == shaka::Symbol("define")) {
     shaka::DataPair& exp_cdr = exp_pair.cdr()->get<DataPair>();
     shaka::Symbol& var = exp_cdr.car()->get<Symbol>();
 

--- a/src/shaka_scheme/system/vm/compiler/Compiler.cpp
+++ b/src/shaka_scheme/system/vm/compiler/Compiler.cpp
@@ -20,11 +20,11 @@ next_instruction) {
 
     return list(create_node(instruction_data), input, next_instruction);
   }
-  // (pair? input)
+    // (pair? input)
   else if (is_pair(input)) {
     Symbol expression_type;
     if (car(input)->get_type() == shaka::Data::Type::SYMBOL) {
-     expression_type = car(input)->get<Symbol>();
+      expression_type = car(input)->get<Symbol>();
     }
 
     // quote case
@@ -35,7 +35,7 @@ next_instruction) {
       return list(create_node(instruction_data), car(cdr(input)),
                   next_instruction);
     }
-    // lambda case
+      // lambda case
     else if (expression_type == Symbol("lambda")) {
       Symbol instruction("close");
       Data instruction_data(instruction);
@@ -47,7 +47,7 @@ next_instruction) {
                   compile_lambda(body,list(create_node(halt_op))),
                   next_instruction);
     }
-    // if (test then else) case
+      // if (test then else) case
     else if (expression_type == Symbol("if")) {
 
       Symbol instruction("test");
@@ -68,8 +68,10 @@ next_instruction) {
       return compile(test_expression, list(create_node(instruction_data),
                                            then_compiled));
     }
-    // set! case
-    else if (expression_type == Symbol("set!")) {
+      // set! case
+    else if (
+        expression_type == Symbol("set!") ||
+        expression_type == Symbol("define")) {
       Symbol instruction("assign");
       Data instruction_data(instruction);
 
@@ -79,8 +81,8 @@ next_instruction) {
       return compile(x,list(create_node(instruction_data),
                             var,next_instruction));
     }
-    // call/cc case
-    else if (expression_type == Symbol("call/cc")) {
+      // call/cc case
+        else if (expression_type == Symbol("call/cc")) {
       Symbol conti_instruction("conti");
       Expression conti_op = create_node(Data(conti_instruction));
 
@@ -101,7 +103,7 @@ next_instruction) {
         return list(create_node(frame_op), next_instruction, c);
       }
     }
-    // application
+      // application
     else {
       Symbol apply_instruction("apply");
       Expression apply_op = create_node(Data(apply_instruction));

--- a/src/shaka_scheme/system/vm/compiler/Compiler.cpp
+++ b/src/shaka_scheme/system/vm/compiler/Compiler.cpp
@@ -69,10 +69,19 @@ next_instruction) {
                                            then_compiled));
     }
       // set! case
-    else if (
-        expression_type == Symbol("set!") ||
-        expression_type == Symbol("define")) {
+    else if (expression_type == Symbol("set!")) {
       Symbol instruction("assign");
+      Data instruction_data(instruction);
+
+      NodePtr var = car(cdr(input));
+      NodePtr x = car(cdr(cdr(input)));
+
+      return compile(x,list(create_node(instruction_data),
+                            var,next_instruction));
+    }
+
+    else if (expression_type == Symbol("define")) {
+      Symbol instruction("define");
       Data instruction_data(instruction);
 
       NodePtr var = car(cdr(input));

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(macro_shaka_scheme_test TEST_NAME)
     add_executable(${TEST_NAME}
             ${TEST_NAME}.cpp)
     target_link_libraries(${TEST_NAME} Threads::Threads)
-    target_link_libraries(${TEST_NAME} gmock gtest gmock_main)
+    target_link_libraries(${TEST_NAME} gmock gtest gtest_main)
     target_link_libraries(${TEST_NAME} ${SHAKA_SCHEME_LIBRARY_NAME})
     set_target_properties(${TEST_NAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/tst)

--- a/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
+++ b/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
@@ -1,5 +1,6 @@
 #include <gmock/gmock.h>
 
+#include "shaka_scheme/system/lexer/rules/init.hpp"
 #include "shaka_scheme/system/parser/parser_definitions.hpp"
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
 #include "shaka_scheme/system/parser/syntax_rules/macro_engine.hpp"
@@ -63,6 +64,8 @@ TEST(MacroContext, setup_vm) {
 TEST(MacroContext, other) {
   using namespace shaka::parser;
   using namespace shaka;
+
+  lexer::rules::init_lexer_rules();
   // Given: an input string
   //std::string buf = "(lambda (x) (+ x z) (lambda (y) (- y a)) (lambda (q)
   // a))";
@@ -125,6 +128,8 @@ TEST(MacroContext, other) {
   std::cout << *result.it << std::endl;
 
   run_macro_expansion(result.it, context);
+
+  std::cout << *result.it << std::endl;
 
   for (
     auto binding :


### PR DESCRIPTION
Hi all,

This is the version of Shaka Scheme that I demoed to Dr. Sasaki when I was doing my senior project presentations. **Please check whether there are any eye-raisers for the following code.**

- I added true support for `define` and `set!`. There was a problem with the semantics of lookup between `define` and `set`.
- The lexer now needs to be initialized at runtime using `init_lexer_rules()`. This is a very rough version of this but this will eventually be packaged into some sort of `init_shaka_scheme()` function or something similar.
- Did some work on `MacroContext` which actually does some of the `define` form rewriting for the `lambda`-like syntax.

There's more changes, but I haven't been able to go through them all. Please check the diffs.

Austin