### PR TITLE
Pull request native closure constructor

### DIFF
--- a/src/shaka_scheme/system/vm/Closure.cpp
+++ b/src/shaka_scheme/system/vm/Closure.cpp
@@ -23,6 +23,16 @@ Closure::Closure(EnvPtr env,
     frame(frame),
     variable_arity(arity) {}
 
+Closure::Closure(Callable cl, bool arity) {
+
+    this->env = nullptr;
+    this->func_body = nullptr;
+    this->variable_list = std::vector<shaka::Symbol>(0);
+    this->callable = std::make_shared<Callable>(cl);
+    this->frame = nullptr,
+    this->variable_arity = arity;
+}
+
 Closure::Closure() {
   env = std::make_shared<Environment>(nullptr);
   func_body = std::make_shared<Data>();
@@ -32,8 +42,6 @@ Closure::Closure() {
   variable_arity = false;
 
 }
-
-
 
 NodePtr Closure::get_function_body() {
   return this->func_body;

--- a/src/shaka_scheme/system/vm/Closure.hpp
+++ b/src/shaka_scheme/system/vm/Closure.hpp
@@ -38,6 +38,13 @@ public:
           CallablePtr cl, FramePtr frame, bool arity);
 
   /**
+   * @brief Special purpose constructor for creating NativeClosure instances
+   * @param cl The Callable function object bound to a native C++ function
+   * @param arity Whether or not this object is of variable arity
+   */
+  Closure(Callable cl, bool arity);
+
+  /**
    * @brief Default constructor for Closure class
    * Initializes environment to be an empty environment
    * Initializes function body to be the empty list

--- a/tst/shaka_scheme/system/vm/unit-Closure.cpp
+++ b/tst/shaka_scheme/system/vm/unit-Closure.cpp
@@ -114,6 +114,37 @@ TEST(ClosureUnitTest, extend_environment) {
 }
 
 /**
+ * @brief Test: Using the specialized constructor for NativeClosures
+ */
+TEST(ClosureUnitTest, native_constructor) {
+
+    // Given: A NativeClosure constructed with the specialized Constructor
+
+    Closure string_append_closure(string_append, true);
+
+    // Given: A ValueRib containing the strings "Hello", "Libraries", "Team"
+
+    ValueRib vr = {
+            create_node(String("Hello")),
+            create_node(String("Libraries")),
+            create_node(String("Team"))
+    };
+
+    // When: You invoke the call method on the Value Rib
+
+    ValueRib result = string_append_closure.call(vr);
+
+    // Then: The result will be the string "HelloLibrariesTeam"
+
+    ASSERT_EQ(result[0]->get<shaka::String>(), String("HelloLibrariesTeam"));
+
+    // Then: The Closure object will be correctly identifiable as Native
+
+    ASSERT_TRUE(string_append_closure.is_native_closure());
+
+}
+
+/**
  * @brief Test: Using the call method for a NativeClosure string-append
  */
 TEST(ClosureUnitTest, native_closure) {


### PR DESCRIPTION
Per the request of the Libraries Team, I have added a specialized constructor to the `Closure` class to ease the process of binding `Closure` instances to native C++ callable function objects. This new constructor simply takes in the `Callable` (`std::function<std::deque<NodePtr>(std::deque<NodePtr>)>`), as well as a boolean indicating whether or not this is a variadic procedure, and constructs the appropriate `Closure` object, initializing all of the necessary fields.