### PR TITLE
Pull request vm and compiler unit test fix

### DIFF
--- a/tst/shaka_scheme/system/vm/unit-Compiler.cpp
+++ b/tst/shaka_scheme/system/vm/unit-Compiler.cpp
@@ -77,8 +77,8 @@ TEST(CompilerUnitTest, lambda_test) {
 
   // Then: The resulting assembly instruction should have the following form.
   std::stringstream ss_test;
-  ss_test << "(close (x y) (frame (halt) (refer y (argument (refer x (argument";
-  ss_test << " (refer + (apply))))))) (halt))";
+  ss_test << "(close (x y) (refer y (argument (refer x (argument";
+  ss_test << " (refer + (apply)))))) (halt))";
   ASSERT_EQ(output, ss_test.str());
 
   // Given: The expression (lambda (k) (k 'a) 'b)
@@ -100,7 +100,7 @@ TEST(CompilerUnitTest, lambda_test) {
 
   // Then: The resulting assembly instruction should have the following form.
   std::stringstream ss_test_two;
-  ss_test_two << "(close (k) (frame (refer b (halt)) (refer a (argument ";
+  ss_test_two << "(close (k) (frame (refer b (return)) (refer a (argument ";
   ss_test_two << "(refer k (apply))))) (halt))";
   ASSERT_EQ(output, ss_test_two.str());
 
@@ -120,7 +120,7 @@ TEST(CompilerUnitTest, lambda_test) {
 
   // Then: The resulting assembly instruction should have the following form.
   std::stringstream ss_test_three;
-  ss_test_three <<"(close (a b c) (refer a (refer b (refer c (halt)))) (halt))";
+  ss_test_three <<"(close (a b c) (refer a (refer b (refer c (return)))) (halt))";
   ASSERT_EQ(output, ss_test_three.str());
 
 }
@@ -215,7 +215,7 @@ TEST(CompilerUnitTest, call_cc_test) {
   // Then: The resulting assembly instruction will have the following form.
   std::stringstream ss_test;
   ss_test << "(frame (halt) (conti (argument (close (k) (frame";
-  ss_test << " (refer b (halt)) (refer a (argument (refer k (apply)))))";
+  ss_test << " (refer b (return)) (refer a (argument (refer k (apply)))))";
   ss_test << " (apply)))))";
   ASSERT_EQ(output, ss_test.str());
 }

--- a/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
+++ b/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
@@ -151,7 +151,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
 
   // Given: An Accumulator that is the symbol #f
 
-  NodePtr accumulator = std::make_shared<Data>(Symbol("#f"));
+  NodePtr accumulator = std::make_shared<Data>(Boolean(false));
 
   // Given: A then expression of the form (constant "then" (halt))
   Symbol then_inst("constant");
@@ -240,9 +240,9 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
 
-  // Given: An Accumulator that is the symbol #t
+  // Given: An Accumulator that is the boolean #t
 
-  NodePtr accumulator = std::make_shared<Data>(Symbol("#t"));
+  NodePtr accumulator = std::make_shared<Data>(Boolean(true));
 
   // Given: A then expression of the form (constant "then" (halt))
   Symbol then_inst("constant");
@@ -351,9 +351,10 @@ TEST(HeapVirtualMachineUnitTest, evaluate_assign) {
 
   NodePtr expression = std::make_shared<Data>(assign_var_halt);
 
-  // Given: An EnvPtr that points to an empty environment
+  // Given: An EnvPtr that points to an environment with a binding for 'a
 
   EnvPtr env = std::make_shared<Environment>(nullptr);
+  env->set_value(Symbol("a"), create_node(Number(1)));
 
   // Given: An empty ValueRib
 


### PR DESCRIPTION
This pull request fixes broken unit tests in the Compiler and HeapVirtualMachine unit tests. All tests in both unit-HeapVirtualMachine and unit-Compiler are now passing. The failed tests were due to either the new functionality added to the Environment to allow for `(define ..)` vs `(set! ..)` semantics, a HVM unit test that needed to be changed from `Symbol("#t")` and `Symbol("#f")` to `Boolean`, and a couple of Compiler tests that had not been updated to reflect the change from `halt` to `return` being chosen as the next expression for compilation of `lambdas` 