### PR TITLE
Added required defs for prim. forms in unit test

### DIFF
--- a/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
+++ b/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
@@ -39,6 +39,18 @@ TEST(MacroContext, setup_vm) {
   std::cout << *expr << std::endl;
 
   EnvPtr env = std::make_shared<Environment>(nullptr);
+
+  env->set_value(Symbol("define"), create_node(PrimitiveFormMarker("define")));
+  env->set_value(Symbol("set!"), create_node(PrimitiveFormMarker("set!")));
+  env->set_value(Symbol("lambda"), create_node(PrimitiveFormMarker("lambda")));
+  env->set_value(Symbol("quote"), create_node(PrimitiveFormMarker("quote")));
+  env->set_value(Symbol("define-syntax"),
+                 create_node(PrimitiveFormMarker("define-syntax")));
+  env->set_value(Symbol("let-syntax"),
+                 create_node(PrimitiveFormMarker("let-syntax")));
+  env->set_value(Symbol("syntax-rules"),
+                 create_node(PrimitiveFormMarker("syntax-rules")));
+
   std::deque<NodePtr> value_rib;
   std::shared_ptr<CallFrame> frame_ptr = std::make_shared<CallFrame>();
 


### PR DESCRIPTION
Just needed to add bindings for the symbols to primitive forms in the top-level environment in the unit test. A small fix. **Please review and determine whether there are any more issues related to this unit test.**