### PR TITLE
Bytevector/Vector support in Data, parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/BigInteger.cpp
         src/shaka_scheme/system/gc/mark_procedures.cpp
         src/shaka_scheme/runtime/stdproc/equivalence_predicates.cpp
+        src/shaka_scheme/system/core/lists.cpp
+        src/shaka_scheme/system/core/types.cpp
+        src/shaka_scheme/system/core/vectors.cpp
         )
 
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})

--- a/src/shaka_scheme/system/base/Bytevector.hpp
+++ b/src/shaka_scheme/system/base/Bytevector.hpp
@@ -1,6 +1,8 @@
 #ifndef SHAKA_CORE_BASE_BYTEVECTOR_HPP
 #define SHAKA_CORE_BASE_BYTEVECTOR_HPP
 
+#include <shaka_scheme/system/gc/GCNode.hpp>
+
 #include <initializer_list>
 #include <cctype>
 #include <memory>
@@ -9,7 +11,8 @@ namespace shaka {
 
 class Data;
 
-using NodePtr = std::shared_ptr<Data>;
+//using NodePtr = std::shared_ptr<Data>;
+using NodePtr = gc::GCNode;
 
 /**
  * @brief Represents a Scheme bytevector, a vector which holds only bytes.

--- a/src/shaka_scheme/system/base/Bytevector.hpp
+++ b/src/shaka_scheme/system/base/Bytevector.hpp
@@ -3,8 +3,13 @@
 
 #include <initializer_list>
 #include <cctype>
+#include <memory>
 
 namespace shaka {
+
+class Data;
+
+using NodePtr = std::shared_ptr<Data>;
 
 /**
  * @brief Represents a Scheme bytevector, a vector which holds only bytes.

--- a/src/shaka_scheme/system/base/Data.cpp
+++ b/src/shaka_scheme/system/base/Data.cpp
@@ -42,6 +42,14 @@ shaka::Data::Data(const shaka::Data& other) :
     new(&primitive_form) shaka::PrimitiveFormMarker(other.primitive_form);
     break;
   }
+  case shaka::Data::Type::VECTOR: {
+    new(&vector) shaka::Vector(other.vector);
+    break;
+  }
+  case shaka::Data::Type::BYTEVECTOR: {
+    new(&bytevector) shaka::Bytevector(other.bytevector);
+    break;
+  }
 
 //  case shaka::Data::Type::DATA_NODE: {
 //    new(&data_node) std::shared_ptr<shaka::DataNode>(other.data_node);
@@ -97,6 +105,14 @@ shaka::Data::~Data() {
   }
   case shaka::Data::Type::PRIMITIVE_FORM: {
     this->primitive_form.~PrimitiveFormMarker();
+    break;
+  }
+  case shaka::Data::Type::VECTOR: {
+    this->vector.~Vector();
+    break;
+  }
+  case shaka::Data::Type::BYTEVECTOR: {
+    this->bytevector.~Bytevector();
     break;
   }
 //  case shaka::Data::Type::ENVIRONMENT: {
@@ -176,6 +192,22 @@ shaka::Number& shaka::Data::get<shaka::Number>() {
   return this->number;
 }
 
+template<>
+shaka::Vector& shaka::Data::get<shaka::Vector>() {
+  if (this->get_type() != Type::VECTOR) {
+    throw shaka::TypeException(10, "Could not get() Vector from Data");
+  }
+  return this->vector;
+}
+
+template<>
+shaka::Bytevector& shaka::Data::get<shaka::Bytevector>() {
+  if (this->get_type() != Type::BYTEVECTOR) {
+    throw shaka::TypeException(10, "Could not get() Bytevector from Data");
+  }
+  return this->bytevector;
+}
+
 namespace shaka {
 
 std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs) {
@@ -230,6 +262,30 @@ std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs) {
   case shaka::Data::Type::PRIMITIVE_FORM: {
     PrimitiveFormMarker& temp = rhs.get<PrimitiveFormMarker>();
     lhs << temp;
+    break;
+  }
+  case shaka::Data::Type::VECTOR: {
+    Vector& temp = rhs.get<Vector>();
+    lhs << "#(";
+    if (temp.length() >= 1) {
+      for (std::size_t i = 0; i < temp.length() - 1; ++i) {
+        lhs << *temp[i] << ' ';
+      }
+      lhs << temp[temp.length()-1];
+    }
+    lhs << ")";
+    break;
+  }
+  case shaka::Data::Type::BYTEVECTOR: {
+    Bytevector& temp = rhs.get<Bytevector>();
+    lhs << "#u8(";
+    if (temp.length() >= 1) {
+      for (std::size_t i = 0; i < temp.length() - 1; ++i) {
+        lhs << temp[i] << ' ';
+      }
+      lhs << temp[temp.length()-1];
+    }
+    lhs << ")";
     break;
   }
 

--- a/src/shaka_scheme/system/base/Data.hpp
+++ b/src/shaka_scheme/system/base/Data.hpp
@@ -14,6 +14,9 @@
 #include "shaka_scheme/system/base/IEnvironment.hpp"
 #include "shaka_scheme/system/base/DataPair.hpp"
 #include "shaka_scheme/system/base/PrimitiveFormMarker.hpp"
+#include "shaka_scheme/system/base/Vector.hpp"
+#include "shaka_scheme/system/base/Bytevector.hpp"
+
 #include "shaka_scheme/system/vm/Closure.hpp"
 #include "shaka_scheme/system/vm/CallFrame.hpp"
 #include "shaka_scheme/system/gc/GCNode.hpp"
@@ -32,6 +35,9 @@ class Environment;
 class DataPair;
 class UserStructData;
 class Closure;
+class Vector;
+class Bytevector;
+
 class CallFrame;
 class PrimitiveFormMarker;
 
@@ -56,7 +62,9 @@ public:
     CLOSURE,
     CALL_FRAME,
     NULL_LIST,
-    PRIMITIVE_FORM
+    PRIMITIVE_FORM,
+    VECTOR,
+    BYTEVECTOR
   };
 private:
   Type type_tag;
@@ -70,6 +78,8 @@ private:
     shaka::Closure closure;
     shaka::CallFrame call_frame;
     shaka::PrimitiveFormMarker primitive_form;
+    shaka::Vector vector;
+    shaka::Bytevector bytevector;
   };
 
 public:
@@ -112,6 +122,16 @@ public:
   Data(shaka::PrimitiveFormMarker other) {
     new(&primitive_form) shaka::PrimitiveFormMarker(other);
     this->type_tag = Type::PRIMITIVE_FORM;
+  }
+
+  Data(shaka::Vector other) {
+    new(&vector) shaka::Vector(other);
+    this->type_tag = Type::VECTOR;
+  }
+
+  Data(shaka::Bytevector other) {
+    new(&bytevector) shaka::Bytevector(other);
+    this->type_tag = Type::BYTEVECTOR;
   }
 
   /**
@@ -163,6 +183,8 @@ template<> shaka::Closure& shaka::Data::get<shaka::Closure>();
 template<> shaka::CallFrame& shaka::Data::get<shaka::CallFrame>();
 template<> shaka::PrimitiveFormMarker& shaka::Data::get<shaka::PrimitiveFormMarker>();
 template<> shaka::Number& shaka::Data::get<shaka::Number>();
+template<> shaka::Vector& shaka::Data::get<shaka::Vector>();
+template<> shaka::Bytevector& shaka::Data::get<shaka::Bytevector>();
 
 std::ostream& operator<<(std::ostream& lhs, shaka::Data rhs);
 

--- a/src/shaka_scheme/system/base/Vector.cpp
+++ b/src/shaka_scheme/system/base/Vector.cpp
@@ -4,11 +4,8 @@
 
 // I included this so I can create unspecified values
 #include "shaka_scheme/system/core/types.hpp"
-#include "shaka_scheme/system/base/Data.hpp"
 
-#include <cctype>
 #include <cstring>
-#include <utility>
 
 namespace shaka {
 

--- a/src/shaka_scheme/system/base/Vector.hpp
+++ b/src/shaka_scheme/system/base/Vector.hpp
@@ -1,13 +1,15 @@
 #ifndef SHAKA_SCHEME_CORE_BASE_VECTOR_HPP
 #define SHAKA_SCHEME_CORE_BASE_VECTOR_HPP
 
-#include "shaka_scheme/system/base/Data.hpp"
-
 #include <initializer_list>
 #include <cctype>
-
+#include <memory>
 
 namespace shaka {
+
+class Data;
+
+using NodePtr = std::shared_ptr<Data>;
 
 class Vector {
   NodePtr* arr;
@@ -74,6 +76,7 @@ public:
    * @brief Swaps the contents of this and the other Vector.
    */
   friend void swap(Vector& lhs, Vector& rhs);
+
 };
 
 } // namespace shaka

--- a/src/shaka_scheme/system/base/Vector.hpp
+++ b/src/shaka_scheme/system/base/Vector.hpp
@@ -1,6 +1,8 @@
 #ifndef SHAKA_SCHEME_CORE_BASE_VECTOR_HPP
 #define SHAKA_SCHEME_CORE_BASE_VECTOR_HPP
 
+#include <shaka_scheme/system/gc/GCNode.hpp>
+
 #include <initializer_list>
 #include <cctype>
 #include <memory>
@@ -9,7 +11,8 @@ namespace shaka {
 
 class Data;
 
-using NodePtr = std::shared_ptr<Data>;
+//using NodePtr = std::shared_ptr<Data>;
+using NodePtr = gc::GCNode;
 
 class Vector {
   NodePtr* arr;

--- a/src/shaka_scheme/system/core/lists.cpp
+++ b/src/shaka_scheme/system/core/lists.cpp
@@ -163,14 +163,14 @@ NodePtr reverse_helper(const NodePtr left, const NodePtr right) {
 }
 
 NodePtr reverse(NodePtr first) {
-  if (first->get_type() != shaka::Data::Type::DATA_PAIR) {
-    return create_node(*first);
+  NodePtr head {first};
+  // Create an null list.
+  NodePtr rev_head {shaka::create_node(shaka::Data())};
+  while (head->get_type() != Data::Type::NULL_LIST) {
+    rev_head = core::cons(head->get<shaka::DataPair>().car(), rev_head);
+    head = head->get<shaka::DataPair>().cdr();
   }
-  if (core::is_null_list(core::cdr(first)))  {
-    return core::list(core::car(first));
-  } else {
-    return shaka::core::reverse_helper(core::car(first), reverse(core::cdr(first)));
-  }
+  return rev_head;
 }
 
 

--- a/src/shaka_scheme/system/core/lists.cpp
+++ b/src/shaka_scheme/system/core/lists.cpp
@@ -56,8 +56,7 @@ bool is_null_list(NodePtr node) {
 bool is_proper_list(NodePtr node) {
   // The empty list is a proper list
   if (is_null_list(node)) { return true; }
-  // Lists must be pairs.
-  if (is_null_list(node)) { return true; }
+  // Lists must be pairs if they are not the null list.
   if (!is_pair(node)) { return false; }
   // Get the last cdr of the last pair in the
   // nested structure of pairs within pairs (the list)

--- a/src/shaka_scheme/system/core/lists.cpp
+++ b/src/shaka_scheme/system/core/lists.cpp
@@ -1,0 +1,179 @@
+#include "shaka_scheme/system/core/lists.hpp"
+
+namespace shaka {
+namespace core {
+
+NodePtr cons(NodePtr left, NodePtr right) {
+  return create_node(Data(DataPair(left, right)));
+}
+
+NodePtr car(NodePtr node) {
+  if (node->get_type() != Data::Type::DATA_PAIR) {
+    throw shaka::TypeException(10001, "car(): Data does not hold DataPair");
+  }
+  return node->get<DataPair>().car();
+}
+
+NodePtr cdr(NodePtr node) {
+  if (node->get_type() != Data::Type::DATA_PAIR) {
+    throw shaka::TypeException(10001, "cdr(): Data does not hold DataPair");
+  }
+  return node->get<DataPair>().cdr();
+}
+
+void set_car(NodePtr pair, NodePtr obj) {
+  if (pair->get_type() != Data::Type::DATA_PAIR) {
+    throw shaka::TypeException(10001, "set_car(): Data does not hold DataPair");
+  }
+  pair->get<DataPair>().set_car(obj);
+}
+
+void set_cdr(NodePtr pair, NodePtr obj) {
+  if (pair->get_type() != Data::Type::DATA_PAIR) {
+    throw shaka::TypeException(10001, "set_cdr(): Data does not hold DataPair");
+  }
+  pair->get<DataPair>().set_cdr(obj);
+}
+
+NodePtr list() {
+  return create_node(Data());
+}
+
+/**
+ * @brief Determines whether a node is a pair.
+ * @param node The node to examine.
+ * @return true if object is a pair, false if otherwise.
+ */
+bool is_pair(NodePtr node) {
+  return node->get_type() == Data::Type::DATA_PAIR;
+}
+
+
+bool is_null_list(NodePtr node) {
+  return node->get_type() == Data::Type::NULL_LIST;
+}
+
+bool is_proper_list(NodePtr node) {
+  // The empty list is a proper list
+  if (is_null_list(node)) { return true; }
+  // Lists must be pairs.
+  if (is_null_list(node)) { return true; }
+  if (!is_pair(node)) { return false; }
+  // Get the last cdr of the last pair in the
+  // nested structure of pairs within pairs (the list)
+  auto it = node;
+  while (is_pair(it)) {
+    it = cdr(it);
+  }
+  // If the last item is a null list, it is proper list.
+  return is_null_list(it);
+}
+
+bool is_improper_list(NodePtr node) {
+  // Lists must be pairs.
+  if (!is_pair(node)) { return false; }
+  // Get the last cdr of the last pair in the
+  // nested structure of pairs within pairs (the list)
+  auto it = node;
+  while (is_pair(it)) {
+    it = cdr(it);
+  }
+  // If the last item is not null list, it is not a proper list.
+  return !is_null_list(it);
+}
+
+std::size_t length(NodePtr node) {
+  if (node->get_type() == shaka::Data::Type::NULL_LIST) {
+    return 0;
+  }
+  else if (node->get_type() != shaka::Data::Type::DATA_PAIR) {
+    throw shaka::TypeException(1000, "length(): data is not a pair");
+  }
+  int count = 0;
+  auto it = node;
+  for (; core::is_pair(it); it = core::cdr(it)) {
+    ++count;
+  }
+  if (it->get_type() != shaka::Data::Type::NULL_LIST) {
+    throw shaka::TypeException(1001, "length(): data is not a proper list");
+  }
+  return count;
+}
+
+NodePtr append() {
+  return list();
+}
+
+NodePtr append(NodePtr first) {
+  return first;
+}
+
+NodePtr append(NodePtr first, NodePtr second) {
+  // The first argument must be a proper list.
+  if (!is_proper_list(first)) {
+    throw shaka::TypeException(2002, "append(): first argument is not a "
+        "proper list");
+  }
+  // Return the second argument if the first argument is a null list.
+  if (is_null_list(first)) { return second; }
+
+  // Otherwise, cons everything from first with the second after it.
+  // First, create the root node as a list with just the first item of first.
+  NodePtr root = cons(car(first), create_node(Data()));
+  NodePtr list_it = root;
+  // Get the NodePtr iterator for the cdr of the first list.
+  NodePtr it = cdr(first);
+  // While it is still a pair
+  while (it->get_type() == shaka::Data::Type::DATA_PAIR) {
+    // Append the next pair onto the list.
+    set_cdr(list_it, cons(car(it), create_node(Data())));
+    list_it = cdr(list_it);
+    // Iterate.
+    it = cdr(it);
+  }
+
+  // If second is not a pair, set cdr of the list to be second.
+  if (!is_pair(second)) {
+    set_cdr(list_it, second);
+    return root;
+  }
+
+  // Otherwise, we need to iterate through second like first.
+  it = second;
+  set_cdr(list_it, cons(car(second), create_node(Data())));
+
+  // While it is still a pair
+  while (it->get_type() == shaka::Data::Type::DATA_PAIR) {
+    // Append the next pair onto the list.
+    set_cdr(list_it, cons(car(it), create_node(Data())));
+    list_it = cdr(list_it);
+    // Iterate.
+    if (!is_pair(it)) { break; }
+    it = cdr(it);
+  }
+
+  // If the last item is a not a null list, append it.
+  if (!is_null_list(it)) {
+    set_cdr(list_it, it);
+  }
+  return root;
+}
+
+NodePtr reverse_helper(const NodePtr left, const NodePtr right) {
+  return core::cons(right, left);
+}
+
+NodePtr reverse(NodePtr first) {
+  if (first->get_type() != shaka::Data::Type::DATA_PAIR) {
+    return create_node(*first);
+  }
+  if (core::is_null_list(core::cdr(first)))  {
+    return core::list(core::car(first));
+  } else {
+    return shaka::core::reverse_helper(core::car(first), reverse(core::cdr(first)));
+  }
+}
+
+
+} // namespace core
+} // namespace shaka

--- a/src/shaka_scheme/system/core/lists.hpp
+++ b/src/shaka_scheme/system/core/lists.hpp
@@ -2,8 +2,8 @@
 // Created by aytas on 9/12/2017.
 //
 
-#ifndef SHAKA_SCHEME_LISTS_HPP
-#define SHAKA_SCHEME_LISTS_HPP
+#ifndef SHAKA_SCHEME_CORE_LISTS_HPP
+#define SHAKA_SCHEME_CORE_LISTS_HPP
 
 #include <shaka_scheme/system/base/Data.hpp>
 #include <shaka_scheme/system/base/DataPair.hpp>

--- a/src/shaka_scheme/system/core/lists.hpp
+++ b/src/shaka_scheme/system/core/lists.hpp
@@ -13,44 +13,20 @@
 namespace shaka {
 namespace core {
 
-inline NodePtr cons(NodePtr left, NodePtr right) {
-  return create_node(Data(DataPair(left, right)));
-}
+NodePtr cons(NodePtr left, NodePtr right);
 
-inline NodePtr car(NodePtr node) {
-  if (node->get_type() != Data::Type::DATA_PAIR) {
-    throw shaka::TypeException(10001, "car(): Data does not hold DataPair");
-  }
-  return node->get<DataPair>().car();
-}
+NodePtr car(NodePtr node);
 
-inline NodePtr cdr(NodePtr node) {
-  if (node->get_type() != Data::Type::DATA_PAIR) {
-    throw shaka::TypeException(10001, "cdr(): Data does not hold DataPair");
-  }
-  return node->get<DataPair>().cdr();
-}
+NodePtr cdr(NodePtr node);
 
-inline void set_car(NodePtr pair, NodePtr obj) {
-  if (pair->get_type() != Data::Type::DATA_PAIR) {
-    throw shaka::TypeException(10001, "set_car(): Data does not hold DataPair");
-  }
-  pair->get<DataPair>().set_car(obj);
-}
+void set_car(NodePtr pair, NodePtr obj);
 
-inline void set_cdr(NodePtr pair, NodePtr obj) {
-  if (pair->get_type() != Data::Type::DATA_PAIR) {
-    throw shaka::TypeException(10001, "set_cdr(): Data does not hold DataPair");
-  }
-  pair->get<DataPair>().set_cdr(obj);
-}
+void set_cdr(NodePtr pair, NodePtr obj);
 
-inline NodePtr list() {
-  return create_node(Data());
-}
+NodePtr list();
 
 template <typename... Args>
-inline NodePtr list(NodePtr first, Args... rest) {
+NodePtr list(NodePtr first, Args... rest) {
   return shaka::core::cons(first, shaka::core::list(rest...));
 }
 
@@ -59,139 +35,31 @@ inline NodePtr list(NodePtr first, Args... rest) {
  * @param node The node to examine.
  * @return true if object is a pair, false if otherwise.
  */
-inline bool is_pair(NodePtr node) {
-  return node->get_type() == Data::Type::DATA_PAIR;
-}
+bool is_pair(NodePtr node);
 
-inline bool is_null_list(NodePtr node) {
-  return node->get_type() == Data::Type::NULL_LIST;
-}
+bool is_null_list(NodePtr node);
 
-inline bool is_proper_list(NodePtr node) {
-  // The empty list is a proper list
-  if (is_null_list(node)) { return true; }
-  // Lists must be pairs.
-  if (is_null_list(node)) { return true; }
-  if (!is_pair(node)) { return false; }
-  // Get the last cdr of the last pair in the
-  // nested structure of pairs within pairs (the list)
-  auto it = node;
-  while (is_pair(it)) {
-    it = cdr(it);
-  }
-  // If the last item is a null list, it is proper list.
-  return is_null_list(it);
-}
+bool is_proper_list(NodePtr node);
 
-inline bool is_improper_list(NodePtr node) {
-  // Lists must be pairs.
-  if (!is_pair(node)) { return false; }
-  // Get the last cdr of the last pair in the
-  // nested structure of pairs within pairs (the list)
-  auto it = node;
-  while (is_pair(it)) {
-    it = cdr(it);
-  }
-  // If the last item is not null list, it is not a proper list.
-  return !is_null_list(it);
-}
+bool is_improper_list(NodePtr node);
 
-inline std::size_t length(NodePtr node) {
-  if (node->get_type() == shaka::Data::Type::NULL_LIST) {
-    return 0;
-  }
-  else if (node->get_type() != shaka::Data::Type::DATA_PAIR) {
-    throw shaka::TypeException(1000, "length(): data is not a pair");
-  }
-  int count = 0;
-  auto it = node;
-  for (; core::is_pair(it); it = core::cdr(it)) {
-    ++count;
-  }
-  if (it->get_type() != shaka::Data::Type::NULL_LIST) {
-    throw shaka::TypeException(1001, "length(): data is not a proper list");
-  }
-  return count;
-}
+std::size_t length(NodePtr node);
 
-inline NodePtr append() {
-  return list();
-}
+NodePtr append();
 
-inline NodePtr append(NodePtr first) {
-  return first;
-}
+NodePtr append(NodePtr first);
 
-inline NodePtr append(NodePtr first, NodePtr second) {
-  // The first argument must be a proper list.
-  if (!is_proper_list(first)) {
-    throw shaka::TypeException(2002, "append(): first argument is not a "
-        "proper list");
-  }
-  // Return the second argument if the first argument is a null list.
-  if (is_null_list(first)) { return second; }
-
-  // Otherwise, cons everything from first with the second after it.
-  // First, create the root node as a list with just the first item of first.
-  NodePtr root = cons(car(first), create_node(Data()));
-  NodePtr list_it = root;
-  // Get the NodePtr iterator for the cdr of the first list.
-  NodePtr it = cdr(first);
-  // While it is still a pair
-  while (it->get_type() == shaka::Data::Type::DATA_PAIR) {
-    // Append the next pair onto the list.
-    set_cdr(list_it, cons(car(it), create_node(Data())));
-    list_it = cdr(list_it);
-    // Iterate.
-    it = cdr(it);
-  }
-
-  // If second is not a pair, set cdr of the list to be second.
-  if (!is_pair(second)) {
-    set_cdr(list_it, second);
-    return root;
-  }
-
-  // Otherwise, we need to iterate through second like first.
-  it = second;
-  set_cdr(list_it, cons(car(second), create_node(Data())));
-
-  // While it is still a pair
-  while (it->get_type() == shaka::Data::Type::DATA_PAIR) {
-    // Append the next pair onto the list.
-    set_cdr(list_it, cons(car(it), create_node(Data())));
-    list_it = cdr(list_it);
-    // Iterate.
-    if (!is_pair(it)) { break; }
-    it = cdr(it);
-  }
-
-  // If the last item is a not a null list, append it.
-  if (!is_null_list(it)) {
-    set_cdr(list_it, it);
-  }
-  return root;
-}
+NodePtr append(NodePtr first, NodePtr second);
 
 template <typename... Args>
-inline NodePtr append(NodePtr first, NodePtr second, Args... rest) {
+NodePtr append(NodePtr first, NodePtr second, Args... rest) {
   auto node = append(first, second);
   return append(node, rest...);
 }
 
-inline NodePtr reverse_helper(const NodePtr left, const NodePtr right) {
-  return core::cons(right, left);
-}
+NodePtr reverse_helper(const NodePtr left, const NodePtr right);
 
-inline NodePtr reverse(NodePtr first) {
-  NodePtr head {first};
-  NodePtr rev_head {shaka::create_node(shaka::Data())};
-  while(head->get_type() != Data::Type::NULL_LIST) {
-    rev_head = core::cons(head->get<shaka::DataPair>().car(), rev_head);
-    head = head->get<shaka::DataPair>().cdr();
-  }
-  return rev_head;
-}
+NodePtr reverse(NodePtr first);
 
 } // namespace core
 } // namespace shaka

--- a/src/shaka_scheme/system/core/types.cpp
+++ b/src/shaka_scheme/system/core/types.cpp
@@ -1,7 +1,4 @@
-#ifndef SHAKA_SCHEME_TYPES_HPP
-#define SHAKA_SCHEME_TYPES_HPP
-
-#include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/core/types.hpp"
 
 namespace shaka {
 namespace core {
@@ -11,21 +8,27 @@ namespace core {
  * @param node The data to take in
  * @return A boolean of whether the predicate was satisfied.
  */
-bool is_boolean(NodePtr node);
+bool is_boolean(NodePtr node) {
+  return node->get_type() == Data::Type::BOOLEAN;
+}
 
 /**
  * @brief Implements (symbol?).
  * @param node The data to take in
  * @return A boolean of whether the predicate was satisfied.
  */
-bool is_symbol(NodePtr node);
+bool is_symbol(NodePtr node) {
+  return node->get_type() == Data::Type::SYMBOL;
+}
 
 /**
  * @brief Implements (string?).
  * @param node The data to take in
  * @return A boolean of whether the predicate was satisfied.
  */
-bool is_string(NodePtr node);
+bool is_string(NodePtr node) {
+  return node->get_type() == Data::Type::STRING;
+}
 
 /**
  * @brief Checks to see whether a value is the "unspecified" value.
@@ -40,7 +43,9 @@ bool is_string(NodePtr node);
  * system. Here, we provide this function to act as the type predicate for the
  * "unspecified" value.
  */
-bool is_unspecified(NodePtr node);
+bool is_unspecified(NodePtr node) {
+  return node->get_type() == Data::Type::UNSPECIFIED;
+}
 
 /**
  * @brief A helper function to create a Data value with an unspecified value.
@@ -48,7 +53,9 @@ bool is_unspecified(NodePtr node);
  *
  * @implementation_specific
  */
-NodePtr create_unspecified_node();
+NodePtr create_unspecified_node() {
+  return shaka::create_unspecified();
+}
 
 /**
  * @brief Implements (eqv), the literal/memory-equivalence comparison operator.
@@ -56,9 +63,23 @@ NodePtr create_unspecified_node();
  * @param right The right object
  * @return A boolean denoting the equivalence predicate
  */
-bool is_eqv(NodePtr left, NodePtr right);
+bool is_eqv(NodePtr left, NodePtr right) {
+  auto left_type = left->get_type();
+  auto right_type = right->get_type();
+  if (left_type != right_type) {
+    return false;
+  }
+  if (left_type == Data::Type::SYMBOL) {
+    return left->get<Symbol>() == right->get<Symbol>();
+  }
+  else if (left_type == Data::Type::BOOLEAN) {
+    return left->get<Boolean>() == right->get<Boolean>();
+  }
+  else if (left_type == Data::Type::NULL_LIST) {
+    return true;
+  }
+  else return left == right;
+}
 
 } // namespace core
 } // namespace shaka
-
-#endif //SHAKA_SCHEME_TYPES_HPP

--- a/src/shaka_scheme/system/core/types.hpp
+++ b/src/shaka_scheme/system/core/types.hpp
@@ -1,5 +1,5 @@
-#ifndef SHAKA_SCHEME_TYPES_HPP
-#define SHAKA_SCHEME_TYPES_HPP
+#ifndef SHAKA_SCHEME_CORE_TYPES_HPP
+#define SHAKA_SCHEME_CORE_TYPES_HPP
 
 #include "shaka_scheme/system/base/Data.hpp"
 

--- a/src/shaka_scheme/system/core/vectors.cpp
+++ b/src/shaka_scheme/system/core/vectors.cpp
@@ -10,7 +10,7 @@ namespace core {
  */
 NodePtr list_to_vector(NodePtr list) {
   // Find the length of the list.
-  std::size_t length = core::length(list);
+  std::size_t length = shaka::core::length(list);
   shaka::Vector vector(length);
   // Copy the elements from the list over.
   for (std::size_t i = 0; i < length; ++i) {
@@ -35,7 +35,7 @@ NodePtr vector_to_list(NodePtr vector) {
   // For each item in the vector, starting from the back, cons it onto the
   // null list.
   for (std::size_t i = vec.length(); i > 0; --i) {
-    node = core::cons(create_node(*vec[i-1]), node);
+    node = shaka::core::cons(create_node(*vec[i-1]), node);
   }
   return node;
 }

--- a/src/shaka_scheme/system/core/vectors.cpp
+++ b/src/shaka_scheme/system/core/vectors.cpp
@@ -1,0 +1,45 @@
+#include "shaka_scheme/system/core/vectors.hpp"
+
+namespace shaka {
+namespace core {
+
+/**
+ * @brief Converts a proper list into a vector.
+ * @param list A proper list, terminated with a null list
+ * @return A vector containing the same elements as the original list
+ */
+NodePtr list_to_vector(NodePtr list) {
+  // Find the length of the list.
+  std::size_t length = core::length(list);
+  shaka::Vector vector(length);
+  // Copy the elements from the list over.
+  for (std::size_t i = 0; i < length; ++i) {
+    shaka::DataPair& pair = list->get<shaka::DataPair>();
+    vector[i] = pair.car();
+    list = pair.cdr();
+  }
+  // Move the vector into the node to return.
+  return create_node(std::move(vector));
+}
+
+/**
+ * @brief Converts a vector into a proper list.
+ * @param vector A vector of fixed size.
+ * @return A proper list containing the same elements as the original list
+ */
+NodePtr vector_to_list(NodePtr vector) {
+  // Create a null list.
+  shaka::NodePtr node = create_node(shaka::Data());
+  // Get the actual vector.
+  shaka::Vector& vec = vector->get<shaka::Vector>();
+  // For each item in the vector, starting from the back, cons it onto the
+  // null list.
+  for (std::size_t i = vec.length(); i > 0; --i) {
+    node = core::cons(create_node(*vec[i-1]), node);
+  }
+  return node;
+}
+
+} // namespace core
+} // namespace shaka
+

--- a/src/shaka_scheme/system/core/vectors.hpp
+++ b/src/shaka_scheme/system/core/vectors.hpp
@@ -1,0 +1,27 @@
+#ifndef SHAKA_SCHEME_VECTORS_HPP
+#define SHAKA_SCHEME_VECTORS_HPP
+
+#include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/core/lists.hpp"
+
+namespace shaka {
+namespace core {
+
+/**
+ * @brief Converts a proper list into a vector.
+ * @param list A proper list, terminated with a null list
+ * @return A vector containing the same elements as the original list
+ */
+NodePtr list_to_vector(NodePtr list);
+
+/**
+ * @brief Converts a vector into a proper list.
+ * @param vector A vector of fixed size.
+ * @return A proper list containing the same elements as the original list
+ */
+NodePtr vector_to_list(NodePtr vector);
+
+} // namespace core
+} // namespace shaka
+
+#endif //SHAKA_SCHEME_VECTORS_HPP

--- a/src/shaka_scheme/system/core/vectors.hpp
+++ b/src/shaka_scheme/system/core/vectors.hpp
@@ -1,5 +1,5 @@
-#ifndef SHAKA_SCHEME_VECTORS_HPP
-#define SHAKA_SCHEME_VECTORS_HPP
+#ifndef SHAKA_SCHEME_CORE_VECTORS_HPP
+#define SHAKA_SCHEME_CORE_VECTORS_HPP
 
 #include "shaka_scheme/system/base/Data.hpp"
 #include "shaka_scheme/system/core/lists.hpp"

--- a/src/shaka_scheme/system/parser/parser_definitions.cpp
+++ b/src/shaka_scheme/system/parser/parser_definitions.cpp
@@ -98,12 +98,14 @@ using DataConstructor = std::function<NodePtr(ParserResult)>;
  */
 ParserResult parse_simple(ParserInput& in) {
   auto next = in.peek();
+  // Stop if we have no more input or there was a LexerError
   if (next.is_incomplete()) {
     return Incomplete(next);
   } else if (next.is_error()) {
     return LexerError(next);
   }
-  //std::cout << next << std::endl;
+  // Get the singleton, "simple" tokens and convert them into strings,
+  // or return a ParserError
   if (next.token_type == "string") {
     in.get();
     return Complete(create_node(String(next.str)));
@@ -121,6 +123,9 @@ ParserResult parse_simple(ParserInput& in) {
     return Complete(create_node(Number(Integer(std::stoi(next.str)))));
   } else if (next.token_type == "rational") {
     in.get();
+    // When converting the string form of a rational, we need to find the
+    // position of the "/" in the string, and then split into the numerator
+    // and denominator there.
     const auto slash_it = next.str.find("/");
     return Complete(
         create_node(
@@ -138,29 +143,37 @@ ParserResult parse_simple(ParserInput& in) {
 }
 
 ParserResult parse_list(ParserInput& in) {
-  //std::cout << "parse-list" << std::endl;
+  // Create our accumulator list that we will append the parsed elements onto
   auto data_list = core::list();
-  //std::cout << "TOKEN: " << in.peek() << std::endl;
+
+  // We will want to possibly save our tokens in the future
+  /// @todo Make sure that tokens is used to correctly place the consumed
+  /// tokens back onto the input if the input list is incomplete
   std::vector<lexer::LexResult> tokens;
+
+  // Read the (
   if (in.peek().token_type == "paren-left") {
     tokens.emplace_back(in.get());
   }
 
+  // Keep reading elements (datums) while we have not reached the )
   while (in.peek().token_type != "paren-right") {
-    //std::cout << "TOKEN: " << in.peek() << std::endl;
     if (in.peek().is_incomplete()) {
       auto incomp = in.peek();
       auto reversed_list = core::reverse(data_list);
     }
+    // Read in a datum
     ParserResult datum_result = parse_datum(in);
-    //std::cout << "DATUM:" << datum_result << std::endl;
+    // If it was complete, add it onto our list
     if (datum_result.is_complete()) {
       data_list = core::append(data_list, core::list(datum_result.it));
     } else if (in.peek().token_type == "dot") {
+      // However, if we have an improper list, we must end shortly after this.
       in.get();
-      //std::cout << "in.peek(): " << in.peek() << std::endl;
+      // Read in the last datum in the improper list
       datum_result = parse_datum(in);
-      //std::cout << "IMPROPER LIST LAST DATUM: " << datum_result << std::endl;
+      // If the last datum is correct, we must append it as the last item
+      // onto the end of the list
       if (datum_result.is_complete()) {
         data_list = core::append(data_list, datum_result.it);
       } else {
@@ -168,20 +181,104 @@ ParserResult parse_list(ParserInput& in) {
             "last datum for improper list");
       }
     } else {
+      // Otherwise, we have an incomplete parse, and let's return the
+      // Incomplete status which is in the datum result.
       return datum_result;
     }
   }
+  // We must match to the last paren
   if (in.peek().token_type == "paren-right") {
-    //std::cout << "RPAREN: " << in.peek() << std::endl;
     in.get();
-    //std::cout << "END OF LIST: " << in.peek() << std::endl;
     return Complete(data_list);
   } else {
+    // Otherwise, we have a parse error.
     return ParserError(in.peek(),
                        "could not match to closing parens for list");
   }
 }
 
+ParserResult parse_vector(ParserInput& in) {
+  auto data_list = core::list();
+  std::vector<lexer::LexResult> tokens;
+  if (in.peek().token_type == "vector-left") {
+    tokens.emplace_back(in.get());
+  }
+
+  while (in.peek().token_type != "paren-right") {
+    if (in.peek().is_incomplete()) {
+      auto incomp = in.peek();
+      auto reversed_list = core::reverse(data_list);
+    }
+    ParserResult datum_result = parse_datum(in);
+    if (datum_result.is_complete()) {
+      data_list = core::append(data_list, core::list(datum_result.it));
+    } else {
+      return datum_result;
+    }
+  }
+  if (in.peek().token_type == "paren-right") {
+    in.get();
+    // This is the same as parse_list, but we are instead just converting it
+    // into a vector
+    shaka::NodePtr converted_vector = core::list_to_vector(data_list);
+    return Complete(converted_vector);
+  } else {
+    return ParserError(in.peek(),
+                       "could not match to closing parens for vector");
+  }
+}
+
+ParserResult parse_bytevector(ParserInput& in) {
+  // Let us use a vector to hold the elements to have better memory access
+  // patterns
+  std::vector<unsigned char> elements;
+  std::vector<lexer::LexResult> tokens;
+  if (in.peek().token_type == "bytevector-left") {
+    tokens.emplace_back(in.get());
+  }
+
+  while (in.peek().token_type != "paren-right") {
+    if (in.peek().is_incomplete()) {
+      auto incomp = in.peek();
+    }
+    ParserResult datum_result = parse_datum(in);
+    if (datum_result.is_complete()) {
+      auto current_element = *datum_result.it;
+      if (current_element.get_type() != shaka::Data::Type::NUMBER) {
+        return ParserError(in.peek(),
+                           "bytevectors cannot contain non-numbers");
+      }
+      const auto current_number = current_element.get<shaka::Number>();
+      if (current_number.get_type() !=
+          shaka::Number::NumberType::INTEGER) {
+        return ParserError(in.peek(),
+                           "bytevectors cannot contain numbers that are not "
+                               "integers");
+      }
+      const auto current_value = current_number.get<shaka::Integer>();
+      if (current_value.get_value() < 0 || current_value.get_value() > 255) {
+        return ParserError(in.peek(),
+                           "bytevectors can only contain unsigned integers "
+                               "within the range 0-255"
+        );
+      }
+      elements.push_back(static_cast<unsigned char>(current_value.get_value()));
+    } else {
+      return datum_result;
+    }
+  }
+  if (in.peek().token_type == "paren-right") {
+    in.get();
+    shaka::Bytevector bv(elements.size());
+    for (std::size_t i = 0; i < elements.size(); ++i) {
+      bv[i] = std::move(elements[i]);
+    }
+    return Complete(create_node(shaka::Data(std::move(bv))));
+  } else {
+    return ParserError(in.peek(),
+                       "could not match to closing parens for bytevector");
+  }
+}
 
 ParserResult parse_datum(ParserInput& in) {
   while (in.peek().token_type == "comment") {
@@ -219,6 +316,10 @@ ParserResult parse_datum(ParserInput& in) {
     auto next = in.peek();
     if (next.token_type == "paren-left") {
       return parse_list(in);
+    } else if (next.token_type == "vector-left") {
+      return parse_vector(in);
+    } else if (next.token_type == "bytevector-left") {
+      return parse_bytevector(in);
     } else {
       return ParserError(next, "could not parse datum");
     }

--- a/src/shaka_scheme/system/parser/parser_definitions.hpp
+++ b/src/shaka_scheme/system/parser/parser_definitions.hpp
@@ -7,6 +7,8 @@
 
 #include "shaka_scheme/system/lexer/rules/rule_token.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
+#include "shaka_scheme/system/core/vectors.hpp"
+#include "shaka_scheme/system/base/Character.hpp"
 
 #include <deque>
 
@@ -62,6 +64,8 @@ using DataConstructor = std::function<NodePtr(ParserResult)>;
 ParserResult parse_simple(ParserInput& in);
 
 ParserResult parse_list(ParserInput& in);
+ParserResult parse_vector(ParserInput& in);
+ParserResult parse_bytevector(ParserInput& in);
 ParserResult parse_datum(ParserInput& in);
 
 } // namespace shaka

--- a/tst/shaka_scheme/system/base/unit-Vector.cpp
+++ b/tst/shaka_scheme/system/base/unit-Vector.cpp
@@ -2,6 +2,7 @@
 
 #include <shaka_scheme/system/base/Vector.hpp>
 #include <shaka_scheme/system/base/DataPair.hpp>
+#include <shaka_scheme/system/base/Data.hpp>
 
 #include <shaka_scheme/system/exceptions/IndexOutOfBoundsException.hpp>
 #include "shaka_scheme/system/gc/GC.hpp"

--- a/tst/shaka_scheme/system/core/CMakeLists.txt
+++ b/tst/shaka_scheme/system/core/CMakeLists.txt
@@ -1,2 +1,3 @@
 macro_shaka_scheme_test(unit-core-lists)
 macro_shaka_scheme_test(unit-core-types)
+macro_shaka_scheme_test(unit-core-vectors)

--- a/tst/shaka_scheme/system/core/unit-core-vectors.cpp
+++ b/tst/shaka_scheme/system/core/unit-core-vectors.cpp
@@ -1,0 +1,77 @@
+#include <gmock/gmock.h>
+#include <shaka_scheme/system/core/vectors.hpp>
+#include <shaka_scheme/system/base/DataPair.hpp>
+
+/**
+ * @brief Test: Testing (list->vector l)
+ */
+TEST(VectorsUnitTest, list_to_vector_3_elements) {
+  using namespace shaka;
+  const auto& c = shaka::create_node;
+
+  // Given: a list of three numbers
+  NodePtr node = core::list(
+      c(Number(1)),
+      c(Number(2)),
+      c(Number(3))
+  );
+
+  // When: you apply (list->vector)
+  shaka::Vector v(std::move(core::list_to_vector(node)->get<shaka::Vector>()));
+
+  // Then: you should be able to get a shaka::Vector out of it
+  ASSERT_EQ(v.length(), 3);
+
+  // Then: the elements should be #(1 2 3)
+  ASSERT_EQ(v[0]->get<Number>(), Number(1));
+  ASSERT_EQ(v[1]->get<Number>(), Number(2));
+  ASSERT_EQ(v[2]->get<Number>(), Number(3));
+}
+
+/**
+ * @brief Test: Testing (list->vector l)
+ */
+TEST(VectorsUnitTest, vector_to_list_2_elements) {
+  using namespace shaka;
+  const auto& c = shaka::create_node;
+
+  // Given: a vector of 3 items
+  NodePtr node = c(shaka::Vector({
+                                     c(Number(1)),
+                                     c(Number(2)),
+                                     c(Number(3))
+                                 }));
+
+  // When: you apply (vector->list) and get the result
+  NodePtr result = core::vector_to_list(node);
+
+  // Then: the result should be a proper list
+  ASSERT_TRUE(core::is_proper_list(result));
+
+  // Then: the elements should be (1 2 3)
+  ASSERT_EQ(result->get<DataPair>()
+                .car()
+                ->get<Number>(),
+            Number(1));
+  ASSERT_EQ(result->get<DataPair>()
+                .cdr()
+                ->get<DataPair>()
+                .car()
+                ->get<Number>(),
+            Number(2));
+  ASSERT_EQ(result->get<DataPair>()
+                .cdr()
+                ->get<DataPair>()
+                .cdr()
+                ->get<DataPair>()
+                .car()
+                ->get<Number>(),
+            Number(3));
+  ASSERT_EQ(result->get<DataPair>()
+                .cdr()
+                ->get<DataPair>()
+                .cdr()
+                ->get<DataPair>()
+                .cdr()->get_type(),
+            shaka::Data::Type::NULL_LIST);
+}

--- a/tst/shaka_scheme/system/core/unit-core-vectors.cpp
+++ b/tst/shaka_scheme/system/core/unit-core-vectors.cpp
@@ -1,11 +1,20 @@
-#include <gmock/gmock.h>
+
+
 #include <shaka_scheme/system/core/vectors.hpp>
 #include <shaka_scheme/system/base/DataPair.hpp>
+
+#include <shaka_scheme/system/gc/GC.hpp>
+#include <shaka_scheme/system/gc/init_gc.hpp>
+
+#include <gmock/gmock.h>
 
 /**
  * @brief Test: Testing (list->vector l)
  */
 TEST(VectorsUnitTest, list_to_vector_3_elements) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
+
   using namespace shaka;
   const auto& c = shaka::create_node;
 
@@ -32,6 +41,9 @@ TEST(VectorsUnitTest, list_to_vector_3_elements) {
  * @brief Test: Testing (list->vector l)
  */
 TEST(VectorsUnitTest, vector_to_list_3_elements) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
+
   using namespace shaka;
   const auto& c = shaka::create_node;
 

--- a/tst/shaka_scheme/system/core/unit-core-vectors.cpp
+++ b/tst/shaka_scheme/system/core/unit-core-vectors.cpp
@@ -31,7 +31,7 @@ TEST(VectorsUnitTest, list_to_vector_3_elements) {
 /**
  * @brief Test: Testing (list->vector l)
  */
-TEST(VectorsUnitTest, vector_to_list_2_elements) {
+TEST(VectorsUnitTest, vector_to_list_3_elements) {
   using namespace shaka;
   const auto& c = shaka::create_node;
 

--- a/tst/shaka_scheme/system/parser/unit-Parser.cpp
+++ b/tst/shaka_scheme/system/parser/unit-Parser.cpp
@@ -8,6 +8,9 @@
 using namespace shaka;
 /**
  * @brief Test: mock define expression
+ *
+ * @todo Strengthen this unit test since it doesn't check the structure of the
+ * parsed result
  */
 TEST(ParserUnitTest, define) {
   gc::GC garbage_collector;
@@ -18,16 +21,18 @@ TEST(ParserUnitTest, define) {
   // Given: an input string
   std::string buf = "(define a \"hello world\")";
 
-  // Given: a ParserInput loaded with the input string.
+  // Given: a ParserInput loaded with the input string
   parser::ParserInput input(buf);
 
-  // Given: the results will end up in this results vector.
+  // When: the string is parsed
   auto result = parser::parse_datum(input);
+
+  // Then: the results should be printable
   std::cout << result << std::endl;
 }
 
 /**
- * @brief Test: mock define expression
+ * @brief Test: mock set expression
  */
 TEST(ParserUnitTest, set) {
   gc::GC garbage_collector;
@@ -38,10 +43,122 @@ TEST(ParserUnitTest, set) {
   // Given: an input string
   std::string buf = "(set! |low vara| \"hello world\")";
 
-  // Given: a ParserInput loaded with the input string.
+  // Given: a ParserInput loaded with the input string
   parser::ParserInput input(buf);
 
-  // Given: the results will end up in this results vector.
+  // When: the input string is parsed
   auto result = parser::parse_datum(input);
+
+  // Then: the results can be printed out
   std::cout << result << std::endl;
 }
+
+/**
+ * @brief Test: parse vector expression
+ */
+TEST(ParserUnitTest, vector) {
+  // Given: the lexer rules are initialized
+  lexer::rules::init_lexer_rules();
+
+  // Given: an input string with a 3-element vector
+  std::string buf = "#(1 \"hello world\" 'set)";
+
+  // Given: a ParserInput loaded with the input string
+  parser::ParserInput input(buf);
+
+  // When: the input string is parsed
+  auto result = parser::parse_datum(input);
+
+  // Then: the parser result can be unpacked and a shaka::Vector can be
+  // obtained from it
+  Vector v = result.it->get<shaka::Vector>();
+
+  // Then: the vector will be of size 3
+  ASSERT_EQ(v.length(), 3);
+
+  // Then: the first element will be 1
+  ASSERT_EQ(v[0]->get<shaka::Number>(), shaka::Number(1));
+
+  // Then: the second element will be "hello world"
+  ASSERT_EQ(v[1]->get<shaka::String>(), shaka::String("hello world"));
+
+  // Then: the third element will be a list of form (quote set)
+  auto third_element = v[2]->get<shaka::DataPair>();
+  ASSERT_EQ(third_element.car()
+                ->get<shaka::Symbol>(),
+            shaka::Symbol("quote"));
+  ASSERT_EQ(third_element.cdr()
+                ->get<shaka::DataPair>()
+                .car()->get<shaka::Symbol>(),
+            shaka::Symbol("set"));
+  ASSERT_EQ(third_element.cdr()
+                ->get<shaka::DataPair>()
+                .cdr()->get_type(),
+            shaka::Data::Type::NULL_LIST);
+}
+
+/**
+ * @brief Test: parse valid bytevector expression
+ *
+ * @todo Strengthen this unit test since it doesn't check the structure of the
+ * parsed result
+ */
+TEST(ParserUnitTest, bytevector_success) {
+  // Given: the lexer rules are initialized
+  lexer::rules::init_lexer_rules();
+
+  // Given: an input string with a 3-element vector
+  std::string buf = "#u8(0 123 255)";
+
+  // Given: a ParserInput loaded with the input string
+  parser::ParserInput input(buf);
+
+  // When: the input string is parsed
+  auto result = parser::parse_datum(input);
+
+  // Then: the parser result can be unpacked and a shaka::Bytevector can be
+  // obtained from it
+  Bytevector bv = result.it->get<shaka::Bytevector>();
+}
+
+/**
+ * @brief Test: parse invalid bytevector expression with negative integer
+ */
+TEST(ParserUnitTest, bytevector_negative_integer_element_failure) {
+  // Given: the lexer rules are initialized
+  lexer::rules::init_lexer_rules();
+
+  // Given: an invalid bytevector string with a negative integer
+  std::string buf = "#u8(-1)";
+
+  // Given: a ParserInput loaded with the input string
+  parser::ParserInput input(buf);
+
+  // When: the input string is parsed
+  auto result = parser::parse_datum(input);
+
+  // Then: the parser input should be invalid with a ParserError
+  ASSERT_TRUE(result.is_parser_error());
+}
+
+/**
+ * @brief Test: parse invalid bytevector expression with non-Number elements
+ */
+TEST(ParserUnitTest, bytevector_non_number_element_failure) {
+  // Given: the lexer rules are initialized
+  lexer::rules::init_lexer_rules();
+
+  // Given: an invalid bytevector string with a Symbol and String
+  std::string buf = "#u8('set \"hi\")";
+
+  // Given: a ParserInput loaded with the input string
+  parser::ParserInput input(buf);
+
+  // When: the input string is parsed
+  auto result = parser::parse_datum(input);
+
+  // Then: the parser input should be invalid with a ParserError
+  ASSERT_TRUE(result.is_parser_error());
+}
+
+

--- a/tst/shaka_scheme/system/parser/unit-Parser.cpp
+++ b/tst/shaka_scheme/system/parser/unit-Parser.cpp
@@ -57,6 +57,9 @@ TEST(ParserUnitTest, set) {
  * @brief Test: parse vector expression
  */
 TEST(ParserUnitTest, vector) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
+
   // Given: the lexer rules are initialized
   lexer::rules::init_lexer_rules();
 
@@ -104,6 +107,9 @@ TEST(ParserUnitTest, vector) {
  * parsed result
  */
 TEST(ParserUnitTest, bytevector_success) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
+
   // Given: the lexer rules are initialized
   lexer::rules::init_lexer_rules();
 
@@ -125,6 +131,9 @@ TEST(ParserUnitTest, bytevector_success) {
  * @brief Test: parse invalid bytevector expression with negative integer
  */
 TEST(ParserUnitTest, bytevector_negative_integer_element_failure) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
+
   // Given: the lexer rules are initialized
   lexer::rules::init_lexer_rules();
 
@@ -145,6 +154,9 @@ TEST(ParserUnitTest, bytevector_negative_integer_element_failure) {
  * @brief Test: parse invalid bytevector expression with non-Number elements
  */
 TEST(ParserUnitTest, bytevector_non_number_element_failure) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
+
   // Given: the lexer rules are initialized
   lexer::rules::init_lexer_rules();
 


### PR DESCRIPTION
I've revised Bytevector and Vector code, and integrated it into `shaka::Data` and the parsing code. There are new test cases and small revisions here and there.

**Please test whether the parsing rules and bytevector/vector creation code works.** The REPL should automatically have support for bytevectors and vectors since it uses the same parsing logic as the unit/integration tests.

**Please test whether bytevector/vector can be used successfully from `shaka::Data`.**