### PR TITLE
GC Integration, create_node() initialization, NodePtr re-aliased to GCNode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/Bytevector.cpp
         src/shaka_scheme/system/base/Character.cpp
         src/shaka_scheme/system/base/Vector.cpp
-        )
+        src/shaka_scheme/system/gc/init.cpp)
 
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})
 target_compile_options(${SHAKA_SCHEME_LIBRARY_NAME} PRIVATE -Wall -Wextra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/Bytevector.cpp
         src/shaka_scheme/system/base/Character.cpp
         src/shaka_scheme/system/base/Vector.cpp
-        src/shaka_scheme/system/gc/init.cpp)
+        src/shaka_scheme/system/gc/init_gc.cpp)
 
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})
 target_compile_options(${SHAKA_SCHEME_LIBRARY_NAME} PRIVATE -Wall -Wextra

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/Bytevector.cpp
         src/shaka_scheme/system/base/Character.cpp
         src/shaka_scheme/system/base/Vector.cpp
-        src/shaka_scheme/system/gc/init_gc.cpp)
+        src/shaka_scheme/system/gc/init_gc.cpp
+        )
 
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})
 target_compile_options(${SHAKA_SCHEME_LIBRARY_NAME} PRIVATE -Wall -Wextra

--- a/main.cpp
+++ b/main.cpp
@@ -1,21 +1,26 @@
 #include <iostream>
 #include <limits> // for std::numeric_limits for std::cin.ignore()
 #include <vector>
-#include <shaka_scheme/runtime/stdproc/numbers_arithmetic.hpp>
-
+#include "shaka_scheme/system/lexer/rules/init.hpp"
+#include "shaka_scheme/runtime/stdproc/numbers_arithmetic.hpp"
 #include "shaka_scheme/system/exceptions/BaseException.hpp"
 #include "shaka_scheme/system/exceptions/TypeException.hpp"
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
 #include "shaka_scheme/system/vm/compiler/Compiler.hpp"
 #include "shaka_scheme/system/vm/strings.hpp"
 #include "shaka_scheme/system/lexer/rules/rule_token.hpp"
-#include "shaka_scheme/system/lexer/rules/init.hpp"
 #include "shaka_scheme/system/parser/parser_definitions.hpp"
 #include "shaka_scheme/system/parser/syntax_rules/macro_engine.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
+#include "shaka_scheme/system/base/DataPair.hpp"
 
 int main() {
+  using namespace shaka;
   // Given: the lexer rules are initialized
   shaka::lexer::rules::init_lexer_rules();
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   std::cout << "Welcome to Shaka Scheme!" << std::endl;
 

--- a/src/shaka_scheme/system/base/Data.hpp
+++ b/src/shaka_scheme/system/base/Data.hpp
@@ -16,6 +16,7 @@
 #include "shaka_scheme/system/base/PrimitiveFormMarker.hpp"
 #include "shaka_scheme/system/vm/Closure.hpp"
 #include "shaka_scheme/system/vm/CallFrame.hpp"
+#include "shaka_scheme/system/gc/GCNode.hpp"
 
 
 #include <memory>
@@ -36,7 +37,8 @@ class PrimitiveFormMarker;
 
 class Data;
 
-using NodePtr = std::shared_ptr<Data>;
+//using NodePtr = std::shared_ptr<Data>;
+using NodePtr = gc::GCNode;
 
 /**
  * @brief The basic sum type or variant type of all possible Scheme data types.

--- a/src/shaka_scheme/system/base/DataPair.cpp
+++ b/src/shaka_scheme/system/base/DataPair.cpp
@@ -4,12 +4,22 @@
 
 #include "shaka_scheme/system/base/DataPair.hpp"
 #include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/gc/GCNode.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 namespace shaka {
 
-NodePtr create_node(const Data& data) {
+std::shared_ptr<Data> create_node_shared_ptr(const Data& data) {
   return std::make_shared<Data>(data);
 }
+
+std::function<gc::GCNode(const Data&)> create_node;
+/* =
+    [](const Data& data) {
+      return create_node_shared_ptr(data);
+    };
+*/
 
 void swap (shaka::DataPair& lhs, shaka::DataPair& rhs) {
   using std::swap;

--- a/src/shaka_scheme/system/base/DataPair.hpp
+++ b/src/shaka_scheme/system/base/DataPair.hpp
@@ -6,12 +6,16 @@
 #define SHAKA_SCHEME_DATAPAIR_HPP
 
 #include <memory>
+#include <functional>
+
+#include "shaka_scheme/system/gc/GCNode.hpp"
 
 namespace shaka {
 
 class Data;
 
-using NodePtr = std::shared_ptr<Data>;
+//using NodePtr = std::shared_ptr<Data>;
+using NodePtr = gc::GCNode;
 
 /**
  * @brief Creates a managed NodePtr from an object of Data.
@@ -24,7 +28,9 @@ using NodePtr = std::shared_ptr<Data>;
  * or reference counting, we trust that all managed objects will either be
  * managed by user-supplied logic in this function, or through
  */
-NodePtr create_node(const Data& data);
+std::shared_ptr<Data> create_node_shared_ptr(const Data& data);
+
+extern std::function<NodePtr(const Data&)> create_node;
 
 /**
  * @brief The data representation of a Scheme pair.

--- a/src/shaka_scheme/system/gc/GCData.hpp
+++ b/src/shaka_scheme/system/gc/GCData.hpp
@@ -4,7 +4,6 @@
 
 #ifndef SHAKA_SCHEME_GCDATA_HPP
 #define SHAKA_SCHEME_GCDATA_HPP
-
 #include "shaka_scheme/system/base/Data.hpp"
 
 class GC;

--- a/src/shaka_scheme/system/gc/GCNode.cpp
+++ b/src/shaka_scheme/system/gc/GCNode.cpp
@@ -5,37 +5,43 @@
 #include "shaka_scheme/system/gc/GCNode.hpp"
 #include "shaka_scheme/system/gc/GCData.hpp"
 
-
 namespace shaka {
 
-    namespace gc {
-        GCNode::GCNode() :
-          gc_data(nullptr) {}
+namespace gc {
+GCNode::GCNode() :
+    gc_data(nullptr) {}
 
-        GCNode::GCNode(GCData *data) {
-            gc_data = data;
-        }
-
-        GCNode::~GCNode() {}
-
-        Data &GCNode::operator*() const {
-            return this->gc_data->get_data();
-        }
-
-        Data *GCNode::operator->() const {
-            return this->gc_data->get_data_address();
-        }
-
-        GCNode::operator bool() const {
-          return this->gc_data != nullptr;
-        }
-
-        bool operator==(const GCNode& lhs, const GCNode& rhs) {
-          return lhs.gc_data == rhs.gc_data;
-        }
-
-        bool operator!=(const GCNode& lhs, const GCNode& rhs) {
-          return !operator==(lhs, rhs);
-        }
-    }
+GCNode::GCNode(GCData * data) {
+  gc_data = data;
 }
+
+GCNode::GCNode(const GCNode& other) : gc_data(other.gc_data) {}
+
+GCNode::~GCNode() {}
+
+Data& GCNode::operator*() const {
+  return this->gc_data->get_data();
+}
+
+Data * GCNode::operator->() const {
+  return this->gc_data->get_data_address();
+}
+
+Data * GCNode::get() const {
+  return this->gc_data->get_data_address();
+}
+
+GCNode::operator bool() const {
+  return this->gc_data != nullptr;
+}
+
+bool operator==(const GCNode& lhs, const GCNode& rhs) {
+  return lhs.gc_data == rhs.gc_data;
+}
+
+bool operator!=(const GCNode& lhs, const GCNode& rhs) {
+  return !operator==(lhs, rhs);
+}
+
+} //namespace gc
+} //namespace shaka

--- a/src/shaka_scheme/system/gc/GCNode.cpp
+++ b/src/shaka_scheme/system/gc/GCNode.cpp
@@ -3,10 +3,14 @@
 //
 
 #include "shaka_scheme/system/gc/GCNode.hpp"
+#include "shaka_scheme/system/gc/GCData.hpp"
+
 
 namespace shaka {
 
     namespace gc {
+        GCNode::GCNode() :
+          gc_data(nullptr) {}
 
         GCNode::GCNode(GCData *data) {
             gc_data = data;
@@ -14,12 +18,24 @@ namespace shaka {
 
         GCNode::~GCNode() {}
 
-        Data &GCNode::operator*() {
+        Data &GCNode::operator*() const {
             return this->gc_data->get_data();
         }
 
-        Data *GCNode::operator->() {
+        Data *GCNode::operator->() const {
             return this->gc_data->get_data_address();
+        }
+
+        GCNode::operator bool() const {
+          return this->gc_data != nullptr;
+        }
+
+        bool operator==(const GCNode& lhs, const GCNode& rhs) {
+          return lhs.gc_data == rhs.gc_data;
+        }
+
+        bool operator!=(const GCNode& lhs, const GCNode& rhs) {
+          return !operator==(lhs, rhs);
         }
     }
 }

--- a/src/shaka_scheme/system/gc/GCNode.hpp
+++ b/src/shaka_scheme/system/gc/GCNode.hpp
@@ -20,11 +20,13 @@ namespace shaka {
 
             GCNode();
             GCNode(GCData *data);
+            GCNode(const GCNode& other);
             ~GCNode();
 
             Data &operator*() const;
             Data *operator->() const;
 
+            Data *get() const;
             operator bool() const;
 
             friend bool operator==(const GCNode& lhs, const GCNode& rhs);

--- a/src/shaka_scheme/system/gc/GCNode.hpp
+++ b/src/shaka_scheme/system/gc/GCNode.hpp
@@ -5,14 +5,12 @@
 #ifndef SHAKA_SCHEME_GCNODE_HPP
 #define SHAKA_SCHEME_GCNODE_HPP
 
-#include "shaka_scheme/system/base/Data.hpp"
-#include "shaka_scheme/system/base/DataPair.hpp"
-#include "shaka_scheme/system/gc/GCData.hpp"
 
 namespace shaka {
+  class Data;
 
     namespace gc {
-
+      class GCData;
 /**
  * @brief Defines the type of GCNode, the object which will
  * wrap over GCData, providing a managed interface to Data
@@ -20,15 +18,22 @@ namespace shaka {
         class GCNode {
         public:
 
+            GCNode();
             GCNode(GCData *data);
             ~GCNode();
 
-            Data &operator*();
-            Data *operator->();
+            Data &operator*() const;
+            Data *operator->() const;
+
+            operator bool() const;
+
+            friend bool operator==(const GCNode& lhs, const GCNode& rhs);
+            friend bool operator!=(const GCNode& lhs, const GCNode& rhs);
 
         private:
             GCData *gc_data;
         };
+
 
     } // namespace gc
 } // namespace shaka

--- a/src/shaka_scheme/system/gc/init.cpp
+++ b/src/shaka_scheme/system/gc/init.cpp
@@ -1,0 +1,19 @@
+//
+// Created by mortrax on 3/26/18.
+//
+
+#include "shaka_scheme/system/gc/init.hpp"
+
+namespace shaka {
+    namespace gc {
+
+        NodePtrFactory create_node;
+
+        NodePtrFactory init_create_node(GC& gc) {
+            create_node = [&gc](const Data& data) {
+                return gc.create_data(data);
+            };
+        }
+    }
+}
+

--- a/src/shaka_scheme/system/gc/init.hpp
+++ b/src/shaka_scheme/system/gc/init.hpp
@@ -1,0 +1,26 @@
+//
+// Created by mortrax on 3/26/18.
+//
+
+#ifndef SHAKA_SCHEME_INIT_HPP
+#define SHAKA_SCHEME_INIT_HPP
+
+#include <functional>
+#include "shaka_scheme/system/gc/GCNode.hpp"
+#include "shaka_scheme/system/base/Data.hpp"
+
+namespace shaka {
+    namespace gc {
+
+        class GC;
+        using NodePtr = GCNode;
+        using NodePtrFactory = std::function<NodePtr(const Data&)>;
+
+        NodePtrFactory init_create_node(GC& gc);
+
+
+
+    }
+}
+
+#endif //SHAKA_SCHEME_INIT_HPP

--- a/src/shaka_scheme/system/gc/init_gc.cpp
+++ b/src/shaka_scheme/system/gc/init_gc.cpp
@@ -3,15 +3,16 @@
 //
 
 #include "shaka_scheme/system/gc/init.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/base/DataPair.hpp"
 
 namespace shaka {
     namespace gc {
 
-        NodePtrFactory create_node;
-
-        NodePtrFactory init_create_node(GC& gc) {
+        void init_create_node(GC& gc) {
             create_node = [&gc](const Data& data) {
-                return gc.create_data(data);
+
+                return GCNode(gc.create_data(data));
             };
         }
     }

--- a/src/shaka_scheme/system/gc/init_gc.cpp
+++ b/src/shaka_scheme/system/gc/init_gc.cpp
@@ -2,7 +2,7 @@
 // Created by mortrax on 3/26/18.
 //
 
-#include "shaka_scheme/system/gc/init.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 #include "shaka_scheme/system/gc/GC.hpp"
 #include "shaka_scheme/system/base/DataPair.hpp"
 

--- a/src/shaka_scheme/system/gc/init_gc.hpp
+++ b/src/shaka_scheme/system/gc/init_gc.hpp
@@ -2,8 +2,8 @@
 // Created by mortrax on 3/26/18.
 //
 
-#ifndef SHAKA_SCHEME_INIT_HPP
-#define SHAKA_SCHEME_INIT_HPP
+#ifndef SHAKA_SCHEME_INIT_GC_HPP
+#define SHAKA_SCHEME_INIT_GC_HPP
 
 #include <functional>
 #include "shaka_scheme/system/gc/GCNode.hpp"
@@ -20,4 +20,4 @@ namespace shaka {
     }
 }
 
-#endif //SHAKA_SCHEME_INIT_HPP
+#endif //SHAKA_SCHEME_INIT_GC_HPP

--- a/src/shaka_scheme/system/gc/init_gc.hpp
+++ b/src/shaka_scheme/system/gc/init_gc.hpp
@@ -14,12 +14,9 @@ namespace shaka {
 
         class GC;
         using NodePtr = GCNode;
-        using NodePtrFactory = std::function<NodePtr(const Data&)>;
 
-        NodePtrFactory init_create_node(GC& gc);
-
-
-
+        void init_create_node(GC& gc);
+    
     }
 }
 

--- a/src/shaka_scheme/system/vm/CallFrame.cpp
+++ b/src/shaka_scheme/system/vm/CallFrame.cpp
@@ -17,7 +17,8 @@ shaka::CallFrame::CallFrame(shaka::Expression ret,
   next_frame(next_frame) {}
 
 shaka::CallFrame::CallFrame() {
-  return_expression = std::make_shared<Data>();
+  //return_expression = std::make_shared<Data>();
+  return_expression = create_node(Data());
   env = std::make_shared<Environment>(nullptr);
   value_rib = std::deque<NodePtr>(0);
   next_frame = nullptr;

--- a/src/shaka_scheme/system/vm/CallFrame.hpp
+++ b/src/shaka_scheme/system/vm/CallFrame.hpp
@@ -13,7 +13,8 @@ namespace shaka {
 
 class CallFrame;
 class Data;
-using NodePtr = std::shared_ptr<Data>;
+//using NodePtr = std::shared_ptr<Data>;
+using NodePtr = gc::GCNode;
 
 using EnvPtr = std::shared_ptr<Environment>;
 using FramePtr = std::shared_ptr<CallFrame>;

--- a/src/shaka_scheme/system/vm/Closure.cpp
+++ b/src/shaka_scheme/system/vm/Closure.cpp
@@ -35,7 +35,8 @@ Closure::Closure(Callable cl, bool arity) {
 
 Closure::Closure() {
   env = std::make_shared<Environment>(nullptr);
-  func_body = std::make_shared<Data>();
+  //func_body = std::make_shared<Data>();
+  func_body = create_node(Data());
   variable_list = std::vector<shaka::Symbol>(0);
   callable = nullptr;
   frame = std::make_shared<CallFrame>();

--- a/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
+++ b/src/shaka_scheme/system/vm/HeapVirtualMachine.cpp
@@ -5,7 +5,6 @@
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
 
-
 namespace shaka {
 
 HeapVirtualMachine::~HeapVirtualMachine() {}
@@ -165,9 +164,9 @@ void HeapVirtualMachine::evaluate_assembly_instruction() {
 
     // Create the function body for the continuation
 
-    NodePtr call_frame = std::make_shared<Data>(*this->frame);
-    NodePtr nuate = std::make_shared<Data>(Symbol("nuate"));
-    NodePtr var = std::make_shared<Data>(Symbol("kont_v000"));
+    NodePtr call_frame = create_node(*this->frame);
+    NodePtr nuate = create_node(Symbol("nuate"));
+    NodePtr var = create_node(Symbol("kont_v000"));
 
     // Create the variable list
 
@@ -180,7 +179,7 @@ void HeapVirtualMachine::evaluate_assembly_instruction() {
     NodePtr func_body = core::list(nuate, call_frame, var);
     EnvPtr empty_env = std::make_shared<Environment>(nullptr);
     NodePtr continuation =
-        std::make_shared<Data>(
+        create_node(
             Closure(
                 empty_env,
                 func_body,

--- a/tst/shaka_scheme/runtime/unit-BooleanProcedures.cpp
+++ b/tst/shaka_scheme/runtime/unit-BooleanProcedures.cpp
@@ -7,8 +7,16 @@
 
 #include "shaka_scheme/system/base/Number.hpp"
 #include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/base/DataPair.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+
+using namespace shaka;
+
 
 TEST(BooleanProceduresUnitTest, notbool) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   using Args = std::deque<shaka::NodePtr>;;
 
@@ -49,6 +57,9 @@ TEST(BooleanProceduresUnitTest, notbool) {
 
 TEST(BooleanProceduresUnitTest, checkbool) {
 
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
+
   using Args = std::deque<shaka::NodePtr>;;
 
   // Given: Boolean arguments that are true and false
@@ -86,6 +97,9 @@ TEST(BooleanProceduresUnitTest, checkbool) {
 }
 
 TEST(BooleanProceduresUnitTest, alltf) {
+
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   using Args = std::deque<shaka::NodePtr>;
 

--- a/tst/shaka_scheme/runtime/unit-NumberProcedures.cpp
+++ b/tst/shaka_scheme/runtime/unit-NumberProcedures.cpp
@@ -6,11 +6,17 @@
 #include "shaka_scheme/runtime/stdproc/numbers_arithmetic.hpp"
 #include "shaka_scheme/system/base/Data.hpp"
 #include "shaka_scheme/system/vm/Closure.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
+#include "shaka_scheme/system/base/DataPair.hpp"
 
+using namespace shaka;
 /**
  * @brief Test: Built in add procedure functionality
  */
 TEST(NumberProceduresUnitTest, add) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using Args = std::deque<shaka::NodePtr>;
 
   // Given: Numeric arguments that are 5 and 7
@@ -36,6 +42,8 @@ TEST(NumberProceduresUnitTest, add) {
 }
 
 TEST(NumberProceduresUnitTest, multiply) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using Args = std::deque<shaka::NodePtr>;
 
   // Given: Numeric argumetns that are 0.5, 20, and 1/2

--- a/tst/shaka_scheme/runtime/unit-pairs_and_lists.cpp
+++ b/tst/shaka_scheme/runtime/unit-pairs_and_lists.cpp
@@ -4,12 +4,16 @@
 
 #include <gmock/gmock.h>
 #include "shaka_scheme/runtime/stdproc/pairs_and_lists.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 
 /**
  * @brief Tests the is-pair? function
  */
 TEST(PairsAndListsUnitTest, is_pair) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using Args = std::deque<shaka::NodePtr>;
 
   // Given: numeric arguments 5 and 5
@@ -33,6 +37,8 @@ TEST(PairsAndListsUnitTest, is_pair) {
  */
 TEST(PairsAndListsUnitTest, cons) {
   using Args = std::deque<shaka::NodePtr>;
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   // Given: numeric arguments 1 and 2 as an Args
   Args pair1{
@@ -59,6 +65,8 @@ TEST(PairsAndListsUnitTest, cons) {
  */
 TEST(PairsAndListsUnitTest, car){
   using Args = std::deque<shaka::NodePtr>;
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   // Given: arguments of a string and a number
   Args args{
@@ -81,6 +89,8 @@ TEST(PairsAndListsUnitTest, car){
  */
 TEST(PairsAndListsUnitTest, cdr){
   using Args = std::deque<shaka::NodePtr>;
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   // Given: a string and a numeric argument
   Args args {
@@ -103,6 +113,8 @@ TEST(PairsAndListsUnitTest, cdr){
  */
 TEST(PairsAndListsUnitTest, set_car){
   using Args = std::deque<shaka::NodePtr>;
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   // Given: the numeric arguments 1 and 2
   Args args {
@@ -132,6 +144,8 @@ TEST(PairsAndListsUnitTest, set_car){
  */
 TEST(PairsAndListsUnitTest, set_cdr){
   using Args = std::deque<shaka::NodePtr>;
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   // Given: The numeric arguments 1 and 2
   Args args {

--- a/tst/shaka_scheme/system/base/unit-DataPair.cpp
+++ b/tst/shaka_scheme/system/base/unit-DataPair.cpp
@@ -3,6 +3,8 @@
 //
 #include "shaka_scheme/system/base/DataPair.hpp"
 #include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 #include <gmock/gmock.h>
 
@@ -10,6 +12,8 @@
  * @brief Test: Constructor and car().
  */
 TEST(DataPairUnitTest, single_constructor_and_cdr) {
+    shaka::gc::GC garbage_collector;
+    shaka::gc::init_create_node(garbage_collector);
     // Given: Data initialized to a (String, null list)
     shaka::String str("Hello world");
     shaka::Data data(str);
@@ -29,6 +33,8 @@ TEST(DataPairUnitTest, single_constructor_and_cdr) {
  * @brief Test: dotted pair and cdr().
  */
 TEST(DataPairUnitTest, double_constructor_and_cdr) {
+    shaka::gc::GC garbage_collector;
+    shaka::gc::init_create_node(garbage_collector);
     // Given: two Datas containing different symbols
     shaka::Symbol sym0("foo");
     shaka::Symbol sym1("bar");
@@ -47,6 +53,8 @@ TEST(DataPairUnitTest, double_constructor_and_cdr) {
 }
 
 TEST(DataPairUnitTest, set_car) {
+    shaka::gc::GC garbage_collector;
+    shaka::gc::init_create_node(garbage_collector);
     // Given: a DataPair initialized to (#t, #f)
     shaka::DataPair pair(
         shaka::Data(shaka::Boolean(true)),
@@ -65,6 +73,8 @@ TEST(DataPairUnitTest, set_car) {
 }
 
 TEST(DataPairUnitTest, set_cdr) {
+    shaka::gc::GC garbage_collector;
+    shaka::gc::init_create_node(garbage_collector);
     // Given: a DataPair initialized to (#t, #f)
     shaka::DataPair pair(
         shaka::Data(shaka::Boolean(true)),

--- a/tst/shaka_scheme/system/base/unit-Environment.cpp
+++ b/tst/shaka_scheme/system/base/unit-Environment.cpp
@@ -5,6 +5,8 @@
 #include <gmock/gmock.h>
 #include "shaka_scheme/system/base/Environment.hpp"
 #include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 using namespace shaka;
 
@@ -12,6 +14,8 @@ using namespace shaka;
  * @brief Test: Constructor with null pointer and parent pointer
  */
 TEST(EnvironmentUnitTest, parent_constructor) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: an environment with parent as null pointer.
   Environment e(nullptr);
 
@@ -33,6 +37,8 @@ TEST(EnvironmentUnitTest, parent_constructor) {
  * @brief Test: Parent Getter
  */
 TEST(EnvironmentUnitTest, get_parent) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: a pointer to a parent Environment
   //        environment with parent as null pointer.
   Environment e(nullptr);
@@ -55,6 +61,8 @@ TEST(EnvironmentUnitTest, get_parent) {
  * @brief Test: Parent Setter
  */
 TEST(EnvironmentUnitTest, set_parent) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: a pointer to a parent Environment.
   //        a child Environment with parent initialized to null pointer.
   auto parent = std::make_shared<Environment>(nullptr);
@@ -71,6 +79,8 @@ TEST(EnvironmentUnitTest, set_parent) {
  * @brief Test: Value Setter
  */
 TEST(EnvironmentUnitTest, set_value) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: an environment with parent initialized to the null pointer.
   //        a Symbol
   //        a Value
@@ -89,6 +99,8 @@ TEST(EnvironmentUnitTest, set_value) {
  * @brief Test: Value Getter with Success
  */
 TEST(EnvironmentUnitTest, get_value_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: an environment, key and value
   Environment e(nullptr);
   Symbol key1("x");
@@ -118,6 +130,8 @@ TEST(EnvironmentUnitTest, get_value_success) {
  * @brief Test: Value Getter with Failure
  */
 TEST(EnvironmentUnitTest, get_value_invalid_key_failure) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: an environment and key
   Environment e(nullptr);
   Symbol key("x");
@@ -132,6 +146,8 @@ TEST(EnvironmentUnitTest, get_value_invalid_key_failure) {
  * @brief Test: Environment contains Symbol
  */
 TEST(EnvironmentUnitTest, contains) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: an environment and different symbols and values
   Environment e(nullptr);
   Symbol key1("x");
@@ -154,6 +170,8 @@ TEST(EnvironmentUnitTest, contains) {
  * @brief Test: Symbol defined in Environment or Parent Environment
  */
 TEST(EnvironmentUnitTest, is_defined) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: a child environment, parent environment, different symbols and
   //        values
   Environment child(nullptr);
@@ -187,6 +205,8 @@ TEST(EnvironmentUnitTest, is_defined) {
  * @brief Test: Environment keys getter
  */
 TEST(EnvironmentUnitTest, get_keys) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: an environment with defined symbols and values
   Environment e(nullptr);
   Symbol key1("x");
@@ -211,6 +231,8 @@ TEST(EnvironmentUnitTest, get_keys) {
  * @brief Test: Environment bindings getter
  */
 TEST(EnvironmentUnitTest, get_bindings) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: an environment with a symbol/data binding
   Environment e(nullptr);
   Symbol key1("x");

--- a/tst/shaka_scheme/system/base/unit-Vector.cpp
+++ b/tst/shaka_scheme/system/base/unit-Vector.cpp
@@ -4,11 +4,16 @@
 #include <shaka_scheme/system/base/DataPair.hpp>
 
 #include <shaka_scheme/system/exceptions/IndexOutOfBoundsException.hpp>
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
+using namespace shaka;
 /**
  * @brief Test: Constructors for Vector.
  */
 TEST(VectorUnitTest, constructors) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: a size k and an element fill to construct with.
   std::size_t k       = 8;
   shaka::NodePtr fill = create_node(shaka::String("HelloWorld"));
@@ -41,6 +46,8 @@ TEST(VectorUnitTest, constructors) {
  * @brief Test: operator[] for Vector
  */
 TEST(VectorUnitTest, element_access) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   // Given: a Vector with 4 elements
   shaka::Vector bv(4);
 
@@ -66,6 +73,8 @@ TEST(VectorUnitTest, element_access) {
  * @brief Test: copy for Vector
  */
 TEST(VectorUnitTest, copy) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   const auto& c = shaka::create_node;
   // Given: a Vector of size 3 with all elements as Number(1).
@@ -95,6 +104,8 @@ TEST(VectorUnitTest, copy) {
  * @brief Test: move for Vector
  */
 TEST(VectorUnitTest, move) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
 
   const auto& c = shaka::create_node;
   // Given: a Vector of size 3 with all elements as Number(1)

--- a/tst/shaka_scheme/system/core/unit-core-lists.cpp
+++ b/tst/shaka_scheme/system/core/unit-core-lists.cpp
@@ -6,12 +6,15 @@
 
 #include <string>
 #include <sstream>
-
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 /**
  * @brief Test: Testing (car) for list
  */
 TEST(ListsUnitTest, car) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
   // Given: a pair of data put into a NodePtr
   DataPair pair(
@@ -34,6 +37,8 @@ TEST(ListsUnitTest, car) {
  * @brief Test: Testing (cdr) for list
  */
 TEST(ListsUnitTest, cdr) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
   // Given: a pair of data put into a NodePtr
   DataPair pair(
@@ -57,6 +62,8 @@ TEST(ListsUnitTest, cdr) {
  * @brief Test: (cons) for pairs
  */
 TEST(ListsUnitTest, cons) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
   // Given: an arbitrary structure of improper and proper lists
   // '(#t . "Hello world") bar)
@@ -86,6 +93,8 @@ TEST(ListsUnitTest, cons) {
  * @brief Test: (list) for lists
  */
 TEST(ListsUnitTest, list) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
   // Given: three symbols
   NodePtr a = create_node(Symbol("a"));
@@ -108,6 +117,8 @@ TEST(ListsUnitTest, list) {
  * @brief Test: (length) for lists
  */
 TEST(ListsUnitTest, length_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
   // Given: three symbols
   NodePtr a = create_node(Symbol("a"));
@@ -131,6 +142,8 @@ TEST(ListsUnitTest, length_success) {
  * @brief Test: (append) with no arguments
  */
 TEST(ListsUnitTest, append_0_args_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
   // When: you call (append) with no arguments
   NodePtr node = core::append();
@@ -142,6 +155,8 @@ TEST(ListsUnitTest, append_0_args_success) {
  * @brief Test: (append x) with 1 argument
  */
 TEST(ListsUnitTest, append_1_args_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a single node of data
@@ -158,6 +173,8 @@ TEST(ListsUnitTest, append_1_args_success) {
  * @brief Test: (append list second) for single item
  */
 TEST(ListsUnitTest, append_2_args_single_item_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a list of data
@@ -186,6 +203,8 @@ TEST(ListsUnitTest, append_2_args_single_item_success) {
  * @brief Test: (append list second) for proper list
  */
 TEST(ListsUnitTest, append_2_args_proper_list_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a list of data
@@ -218,6 +237,8 @@ TEST(ListsUnitTest, append_2_args_proper_list_success) {
  * @brief Test: (append list second) for improper list
  */
 TEST(ListsUnitTest, append_2_args_improper_list_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a list of data
@@ -251,6 +272,8 @@ TEST(ListsUnitTest, append_2_args_improper_list_success) {
  * @brief Test: (append list second) for improper list
  */
 TEST(ListsUnitTest, append_2_args_first_argument_not_proper_list_failure) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a first argument that is an improper list
@@ -279,6 +302,8 @@ TEST(ListsUnitTest, append_2_args_first_argument_not_proper_list_failure) {
  * @brief Test: (append list second) for 3 or more arguments
  */
 TEST(ListsUnitTest, append_3_args_success) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a list of data

--- a/tst/shaka_scheme/system/core/unit-core-types.cpp
+++ b/tst/shaka_scheme/system/core/unit-core-types.cpp
@@ -3,6 +3,8 @@
 //
 #include <gmock/gmock.h>
 #include <shaka_scheme/system/core/types.hpp>
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 
 
@@ -10,6 +12,8 @@
  * @brief Test: Testing (boolean?)
  */
 TEST(TypesUnitTest, is_boolean) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a boolean node and a null list
@@ -28,6 +32,8 @@ TEST(TypesUnitTest, is_boolean) {
  * @brief Test: Testing (string?)
  */
 TEST(TypesUnitTest, is_string) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a string node and a null list
@@ -46,6 +52,8 @@ TEST(TypesUnitTest, is_string) {
  * @brief Test: Testing (symbol?)
  */
 TEST(TypesUnitTest, is_symbol) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: a symbol node and a null list
@@ -65,6 +73,8 @@ TEST(TypesUnitTest, is_symbol) {
  * predicate for detecting "unspecified" values.
  */
 TEST(TypesUnitTest, is_unspecified) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: an unspecified value node and a null list
@@ -83,6 +93,8 @@ TEST(TypesUnitTest, is_unspecified) {
  * @brief Test: Testing (eqv?)
  */
 TEST(TypesUnitTest, is_eqv) {
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
   using namespace shaka;
 
   // Given: two distinct nodes with the same string value.

--- a/tst/shaka_scheme/system/gc/CMakeLists.txt
+++ b/tst/shaka_scheme/system/gc/CMakeLists.txt
@@ -5,3 +5,5 @@ macro_shaka_scheme_test(unit-GCNode)
 macro_shaka_scheme_test(unit-GCList)
 
 macro_shaka_scheme_test(unit-GC)
+
+macro_shaka_scheme_test(unit-GCInit)

--- a/tst/shaka_scheme/system/gc/unit-GCInit.cpp
+++ b/tst/shaka_scheme/system/gc/unit-GCInit.cpp
@@ -1,0 +1,33 @@
+//
+// Created by mortrax on 4/3/18.
+//
+
+#include <gmock/gmock.h>
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/base/DataPair.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
+#include "shaka_scheme/system/base/Data.hpp"
+#include "shaka_scheme/system/gc/GCNode.hpp"
+
+TEST(GCInitUnitTest, test_initialize_create_node) {
+  // Given: You have created a GC object
+
+  shaka::gc::GC garbage_collector;
+
+  // When: You invoke init_create_node() with the gc as parameter
+
+  shaka::gc::init_create_node(garbage_collector);
+
+  // When: You use the newly bound create_node to create a Data
+
+  shaka::NodePtr number = shaka::create_node(shaka::Data(shaka::Number(5)));
+
+  // Then: The GC object will reflect that you have used it to make an object
+
+  ASSERT_EQ(garbage_collector.get_size(), 1);
+
+  // Then: You can get the Number out of the NodePtr just as you would have
+  // before
+
+  ASSERT_EQ(number->get<shaka::Number>(), shaka::Number(5));
+}

--- a/tst/shaka_scheme/system/gc/unit-GCNode.cpp
+++ b/tst/shaka_scheme/system/gc/unit-GCNode.cpp
@@ -4,44 +4,73 @@
 //
 #include <gmock/gmock.h>
 #include "shaka_scheme/system/gc/GCData.hpp"
-#include "shaka_scheme/system/gc/GCNode.hpp"
 #include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 /**
  * @Test: test_arrow_operator
  */
 TEST (GCNodeUnitTest, test_constructor) {
 
-    //Given: You constructed a GC and a GCData
+  //Given: You constructed a GC and a GCData
 
-    shaka::gc::GC garbage_collector;
+  shaka::gc::GC garbage_collector;
 
-    shaka::gc::GCData *gcd = garbage_collector.create_data(shaka::Number(5));
-    
-    //When: You wrap the GCData in a GCNode
-    
-    shaka::gc::GCNode gcn(gcd);
+  shaka::gc::GCData * gcd = garbage_collector.create_data(shaka::Number(5));
 
-    //Then: the data in gcn is equal to 5
-    
-    ASSERT_EQ(gcn->get<shaka::Number>(), shaka::Number(5));
+  //When: You wrap the GCData in a GCNode
+
+  shaka::gc::GCNode gcn(gcd);
+
+  //Then: the data in gcn is equal to 5
+
+  ASSERT_EQ(gcn->get<shaka::Number>(), shaka::Number(5));
 }
 
 /**
- * @Test: Test dreference operator of GCNode
+ * @Test: Test dereference operator of GCNode
  */
-TEST (GCNodeUnitTest, test_dreference) {
+TEST (GCNodeUnitTest, test_dereference) {
 
-    //Given: You constructed a GC and a GCData
+  //Given: You constructed a GC and a GCData
 
-    shaka::gc::GC garbage_collector;
+  shaka::gc::GC garbage_collector;
 
-    shaka::gc::GCData *gcd = garbage_collector.create_data(shaka::Number(5));
+  shaka::gc::GCData * gcd = garbage_collector.create_data(shaka::Number(5));
 
-    //When: You wrap the GCData in a GCNode
-    
-    shaka::gc::GCNode gcn(gcd);
-    
-    //Then: the data in gcn is equal to 5
-    ASSERT_EQ((*gcn).get<shaka::Number>(), shaka::Number(5));
+  //When: You wrap the GCData in a GCNode
+
+  shaka::gc::GCNode gcn(gcd);
+
+  //Then: the data in gcn is equal to 5
+  ASSERT_EQ((*gcn).get<shaka::Number>(), shaka::Number(5));
+}
+
+/**
+ * @Test: Test get() method of GCNode for pointer equivalence
+ */
+TEST (GCNodeUnitTest, test_get_method) {
+  //Given: You have created a garbage collector object
+
+  shaka::gc::GC garbage_collector;
+
+  //Given: You have bound create_node() to this garbage collector
+
+  shaka::gc::init_create_node(garbage_collector);
+
+  //Given: You have created a Data objects with a Number
+
+  shaka::NodePtr num1 = shaka::create_node(shaka::Data(shaka::Number(1)));
+
+  //Given: You have instantiated an environment
+
+  shaka::EnvPtr env = std::make_shared<shaka::Environment>(nullptr);
+
+  //When: You bind num1 in the environment to the symbol 'num1
+
+  env->set_value(shaka::Symbol("num1"), num1);
+
+  //Then: The address of the bound value should equal the address of the object
+
+  ASSERT_TRUE(num1.get() == env->get_value(shaka::Symbol("num1")).get());
 }

--- a/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
+++ b/tst/shaka_scheme/system/parser/unit-MacroContextChecker.cpp
@@ -4,6 +4,8 @@
 #include "shaka_scheme/system/parser/parser_definitions.hpp"
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
 #include "shaka_scheme/system/parser/syntax_rules/macro_engine.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 using namespace shaka::core;
 using namespace shaka::macro;
@@ -11,6 +13,8 @@ using namespace shaka;
 
 
 TEST(MacroContext, setup_vm) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   const auto& c = create_node;
   NodePtr acc = create_node(Symbol("hi"));
 
@@ -77,6 +81,8 @@ TEST(MacroContext, other) {
   using namespace shaka::parser;
   using namespace shaka;
 
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   lexer::rules::init_lexer_rules();
   // Given: an input string
   //std::string buf = "(lambda (x) (+ x z) (lambda (y) (- y a)) (lambda (q)

--- a/tst/shaka_scheme/system/parser/unit-Parser.cpp
+++ b/tst/shaka_scheme/system/parser/unit-Parser.cpp
@@ -2,12 +2,16 @@
 
 #include "shaka_scheme/system/lexer/rules/init.hpp"
 #include "shaka_scheme/system/parser/parser_definitions.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 using namespace shaka;
 /**
  * @brief Test: mock define expression
  */
 TEST(ParserUnitTest, define) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   // Given: the lexer rules are initialized
   lexer::rules::init_lexer_rules();
 
@@ -26,6 +30,8 @@ TEST(ParserUnitTest, define) {
  * @brief Test: mock define expression
  */
 TEST(ParserUnitTest, set) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   // Given: the lexer rules are initialized
   lexer::rules::init_lexer_rules();
 

--- a/tst/shaka_scheme/system/vm/unit-Closure.cpp
+++ b/tst/shaka_scheme/system/vm/unit-Closure.cpp
@@ -7,6 +7,8 @@
 #include "shaka_scheme/system/vm/CallFrame.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
 #include "shaka_scheme/system/vm/strings.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 using namespace shaka;
 
@@ -15,6 +17,8 @@ using namespace shaka;
  * @brief Test: Constructor usage for constructing generic closure
  */
 TEST(ClosureUnitTest, constructor) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: A pointer to an environment with no bindings
 
@@ -63,6 +67,8 @@ TEST(ClosureUnitTest, constructor) {
  * @brief Test: Usage of extend_environment method
  */
 TEST(ClosureUnitTest, extend_environment) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: A pointer to an environment with no bindings
 
@@ -117,6 +123,8 @@ TEST(ClosureUnitTest, extend_environment) {
  * @brief Test: Using the specialized constructor for NativeClosures
  */
 TEST(ClosureUnitTest, native_constructor) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
     // Given: A NativeClosure constructed with the specialized Constructor
 
@@ -148,6 +156,8 @@ TEST(ClosureUnitTest, native_constructor) {
  * @brief Test: Using the call method for a NativeClosure string-append
  */
 TEST(ClosureUnitTest, native_closure) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: A pointer to an environment with no bindings
 
@@ -202,6 +212,8 @@ TEST(ClosureUnitTest, native_closure) {
  * @brief Test: Creation of a Continuation closure
  */
 TEST(ClosureUnitTest, continuation_closure) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: A pointer to an environment with no bindings
 
@@ -262,6 +274,8 @@ TEST(ClosureUnitTest, continuation_closure) {
  * @brief Test: Closure functionality with a variadic lambda
  */
 TEST(ClosureUnitTest, variadic_lambda) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Simulation of the behavior of a procedure such as (lambda x x)
 

--- a/tst/shaka_scheme/system/vm/unit-Compiler.cpp
+++ b/tst/shaka_scheme/system/vm/unit-Compiler.cpp
@@ -4,6 +4,8 @@
 
 #include <gmock/gmock.h>
 #include "shaka_scheme/system/vm/compiler/Compiler.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 using namespace shaka;
 using namespace core;
@@ -12,6 +14,8 @@ using namespace core;
  * @brief Test: compile() changing symbols to 'refer' instructions
  */
 TEST(CompilerUnitTest, is_symbol_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   // Given: A symbol "a"
   Symbol var("a");
   Data var_data(var);
@@ -31,6 +35,8 @@ TEST(CompilerUnitTest, is_symbol_test) {
  * @brief Test: compile() changing quote expressions to 'constant' instructions
  */
 TEST(CompilerUnitTest, quote_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   Compiler compiler;
 
   // Given: The expression (quote "Hello")
@@ -55,6 +61,8 @@ TEST(CompilerUnitTest, quote_test) {
  * @brief Test: compile() changing lambda expressions to 'close' instructions
  */
 TEST(CompilerUnitTest, lambda_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   Compiler compiler;
   Data x_data(Symbol("x"));
   Data y_data(Symbol("y"));
@@ -129,6 +137,8 @@ TEST(CompilerUnitTest, lambda_test) {
  * @brief Test: compile() changing if expressions to 'test' instructions
  */
 TEST(CompilerUnitTest, if_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   Compiler compiler;
   Data x_data(Symbol("x"));
   Data y_data(Symbol("y"));
@@ -166,6 +176,8 @@ TEST(CompilerUnitTest, if_test) {
  * @brief Test: compile() changing set expressions to 'assign' instructions
  */
 TEST(CompilerUnitTest, set_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   Compiler compiler;
   NodePtr set_bang = create_node(Data(Symbol("set!")));
   Data x_data(Symbol("x"));
@@ -189,6 +201,8 @@ TEST(CompilerUnitTest, set_test) {
  * @brief Test: compile() changing call/cc expressions to 'frame' instructions
  */
 TEST(CompilerUnitTest, call_cc_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   Compiler compiler;
 
   // Given: The expression (lambda (k) (k 'a) 'b)
@@ -224,6 +238,8 @@ TEST(CompilerUnitTest, call_cc_test) {
  * @brief Test: compile() changing applications to 'frame' instructions
  */
 TEST(CompilerUnitTest, application_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   Compiler compiler;
   Data x_data(Symbol("x"));
   Data y_data(Symbol("y"));
@@ -251,6 +267,8 @@ TEST(CompilerUnitTest, application_test) {
  * @brief Test: compile() changing constants to 'constant' instructions
  */
 TEST(CompilerUnitTest, constant_test) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   Compiler compiler;
   Data hello(String("hello"));
 

--- a/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
+++ b/tst/shaka_scheme/system/vm/unit-HeapVirtualMachine.cpp
@@ -7,6 +7,8 @@
 #include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
 #include "shaka_scheme/system/core/lists.hpp"
 #include "shaka_scheme/system/vm/strings.hpp"
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
 
 using namespace shaka;
 
@@ -14,16 +16,18 @@ using namespace shaka;
  * @brief Test: evaluate_assembly_instruction() with (halt) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_halt) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An accumulator that holds a NodePtr with symbol 'result
   Symbol acc_value("result");
-  NodePtr accumulator = std::make_shared<Data>(acc_value);
+  NodePtr accumulator = create_node(acc_value);
 
   // Given: An assembly instruction of the form (halt)
   Symbol instruction("halt");
   Data instruction_data(instruction);
   DataPair instruction_pair(instruction_data);
-  NodePtr expression = std::make_shared<Data>(instruction_pair);
+  NodePtr expression = create_node(instruction_pair);
 
   // Given: A pointer to an Environment with a null parent pointer
   EnvPtr env = std::make_shared<Environment>(nullptr);
@@ -46,6 +50,8 @@ TEST(HeapVirtualMachineUnitTest, evaluate_halt) {
  * @brief Test: evaluate_assembly_instruction() with (refer var x) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   // Given: An assembly instruction of the form (refer a (halt))
   Symbol instruction("refer");
   Symbol var("a");
@@ -60,7 +66,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
   Data instruction_data(instruction);
   DataPair refer_var_x(instruction_data, var_x_pair);
 
-  NodePtr expression = std::make_shared<Data>(refer_var_x);
+  NodePtr expression = create_node(refer_var_x);
 
   // Given: A pointer to Environment containing a binding for the symbol 'a
   EnvPtr env = std::make_shared<Environment>(nullptr);
@@ -94,6 +100,8 @@ TEST(HeapVirtualMachineUnitTest, evaluate_refer) {
  * @brief Test: evaluate_assembly_instruction() with (constant obj x) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_constant) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   // Given: An assembly instruction of the form (constant "Hello" (halt))
 
   Symbol instruction("constant");
@@ -110,7 +118,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_constant) {
   Data instruction_data(instruction);
   DataPair constant_obj_x(instruction_data, constant_obj_pair);
 
-  NodePtr expression = std::make_shared<Data>(constant_obj_x);
+  NodePtr expression = create_node(constant_obj_x);
 
   // Given: A pointer to an empty environment frame
 
@@ -148,10 +156,12 @@ TEST(HeapVirtualMachineUnitTest, evaluate_constant) {
  * @brief Test: evaluate_assembly_instruction() with (test then else) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An Accumulator that is the symbol #f
 
-  NodePtr accumulator = std::make_shared<Data>(Boolean(false));
+  NodePtr accumulator = create_node(Boolean(false));
 
   // Given: A then expression of the form (constant "then" (halt))
   Symbol then_inst("constant");
@@ -170,7 +180,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
 
   DataPair const_obj_halt(then_inst_data, obj_halt_pair);
 
-  NodePtr expr = std::make_shared<Data>(const_obj_halt);
+  NodePtr expr = create_node(const_obj_halt);
 
   // Given: An else expression of the form (constant "else" (halt))
 
@@ -185,7 +195,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
 
   DataPair const_else_obj_halt(else_inst_data, else_obj_halt_pair);
 
-  NodePtr expr2 = std::make_shared<Data>(const_else_obj_halt);
+  NodePtr expr2 = create_node(const_else_obj_halt);
 
   // Given: An assembly instruction of the form (test then else)
 
@@ -197,7 +207,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
 
   DataPair test_then_else(instruction_data, then_else_pair);
 
-  NodePtr expression = std::make_shared<Data>(test_then_else);
+  NodePtr expression = create_node(test_then_else);
 
   // Given: An EnvPtr that points to an empty environment
 
@@ -239,10 +249,12 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_else) {
  * @brief Test: evaluate_assembly_instruction() with (test then else) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An Accumulator that is the boolean #t
 
-  NodePtr accumulator = std::make_shared<Data>(Boolean(true));
+  NodePtr accumulator = create_node(Boolean(true));
 
   // Given: A then expression of the form (constant "then" (halt))
   Symbol then_inst("constant");
@@ -261,7 +273,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
 
   DataPair const_obj_halt(then_inst_data, obj_halt_pair);
 
-  NodePtr expr = std::make_shared<Data>(const_obj_halt);
+  NodePtr expr = create_node(const_obj_halt);
 
   // Given: An else expression of the form (constant "else" (halt))
 
@@ -276,7 +288,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
 
   DataPair const_else_obj_halt(else_inst_data, else_obj_halt_pair);
 
-  NodePtr expr2 = std::make_shared<Data>(const_else_obj_halt);
+  NodePtr expr2 = create_node(const_else_obj_halt);
 
   // Given: An assembly instruction of the form (test then else)
 
@@ -288,7 +300,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
 
   DataPair test_then_else(instruction_data, then_else_pair);
 
-  NodePtr expression = std::make_shared<Data>(test_then_else);
+  NodePtr expression = create_node(test_then_else);
 
   // Given: An EnvPtr that points to an empty environment
 
@@ -330,10 +342,12 @@ TEST(HeapVirtualMachineUnitTest, evaluate_test_then) {
  * @brief Test: evaluate_assembly_instruction() with (assign var x) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_assign) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An Accumulator with the Symbol("accumulator");
 
-  Accumulator acc = std::make_shared<Data>(Symbol("accumulator"));
+  Accumulator acc = create_node(Symbol("accumulator"));
 
   // Given: An assembly instruction of the form (assign a (halt))
   Symbol instruction("assign");
@@ -349,7 +363,7 @@ TEST(HeapVirtualMachineUnitTest, evaluate_assign) {
 
   DataPair assign_var_halt(instruction_data, var_halt_pair);
 
-  NodePtr expression = std::make_shared<Data>(assign_var_halt);
+  NodePtr expression = create_node(assign_var_halt);
 
   // Given: An EnvPtr that points to an environment with a binding for 'a
 
@@ -383,10 +397,12 @@ TEST(HeapVirtualMachineUnitTest, evaluate_assign) {
  * @brief Test: evaluate_assembly_instruction() with (frame x ret) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_frame) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An Accumulator containing the Symbol("finale")
 
-  Accumulator accumulator = std::make_shared<Data>(Symbol("finale"));
+  Accumulator accumulator = create_node(Symbol("finale"));
 
   // Given: An assembly instruction of the form (frame (halt) (halt))
 
@@ -403,14 +419,14 @@ TEST(HeapVirtualMachineUnitTest, evaluate_frame) {
 
   DataPair frame_halt_halt(frame_data, halt_halt);
 
-  NodePtr expression = std::make_shared<Data>(frame_halt_halt);
+  NodePtr expression = create_node(frame_halt_halt);
 
   // Given: An EnvPtr with bindings [a : "Hello", b : "World"]
 
   EnvPtr env = std::make_shared<Environment>(nullptr);
 
-  env->set_value(Symbol("a"), std::make_shared<Data>(String("Hello")));
-  env->set_value(Symbol("b"), std::make_shared<Data>(String("World")));
+  env->set_value(Symbol("a"), create_node(String("Hello")));
+  env->set_value(Symbol("b"), create_node(String("World")));
 
   // Given: A ValueRib containing strings "RVal1" "RVal2" "RVal3"
 
@@ -499,6 +515,8 @@ TEST(HeapVirtualMachineUnitTest, evaluate_frame) {
  * @brief Test: evaluate_assembly_instruction() with (argument x) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_argument) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An Accumulator containing the symbol 'banana
 
@@ -557,6 +575,8 @@ TEST(HeapVirtualMachineUnitTest, evaluate_argument) {
  * @brief Test: evaluate_assembly_instruction() with (return) as exp
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_return) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An Accumulator containing the symbol 'finale
 
@@ -644,10 +664,12 @@ TEST(HeapVirtualMachineUnitTest, evaluate_return) {
  * @brief Test: evaluate_assembly_instruction() w/ (close vars body x) as expr
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_close) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An empty accumulator
 
-  Accumulator acc = std::make_shared<Data>();
+  Accumulator acc = create_node(Data());
 
   // Given: An assembly instruction of the form...
   // (close (a) (refer a (halt)) (halt))
@@ -732,6 +754,8 @@ TEST(HeapVirtualMachineUnitTest, evaluate_close) {
  * @brief Test: evaluate_assembly_instruction() with (conti x) as expr
  */
 TEST(HeapVirtualMachineUnitTest, evaluate_conti) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: An assembly instruction of the form (conti (halt))
 
@@ -821,6 +845,8 @@ TEST(HeapVirtualMachineUnitTest, evaluate_conti) {
  * @brief Test: evaluate_assembly_instruction() with (apply) as expr
  */
 TEST(HeapVirtualMachineUnitTest, eval_apply) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: A native-closure to wrap the append method for strings
 
@@ -1053,6 +1079,8 @@ TEST(HeapVirtualMachineUnitTest, eval_apply) {
  * @brief Test: evaluate_assembly_instruction method with (nuate s var) as expr
  */
 TEST(HeapVirtualMachineUnitTest, eval_nuate) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
 
   // Given: A closure that represents the procedure (lambda (k) (k 'a) 'b)
 
@@ -1234,6 +1262,8 @@ TEST(HeapVirtualMachineUnitTest, eval_nuate) {
  * @brief Test: The difference between standard closure vs. continuation
  */
 TEST(HeapVirtualMachineUnitTest, closure_vs_continuation) {
+  gc::GC garbage_collector;
+  gc::init_create_node(garbage_collector);
   // Given: A closure that represents the procedure (lambda (k) (k 'a) 'b)
 
   EnvPtr env = std::make_shared<Environment>(nullptr);


### PR DESCRIPTION
This pull request implements the integration of the Garbage Collector with the rest of the code base. `NodePtr` has been re-aliased to `GCNode`, and an initialization mechanism has been implemented that allows the `create_node()` procedure to be dynamically bound to a procedure that creates `Data` objects that are managed by the garbage collector. All unit tests have been fixed by introducing GC instances into the appropriate test environments and calling `init_create_node()`. All unit tests should hopefully be passing again. We need to figure out a way to trick the type checker into allowing us to choose whether to bind `create_node` to the old procedure that returned a `std::shared_ptr<Data>` or to the new one that returns a `GCNode` without complaining about the `NodePtr` aliasing. For now, this is a quick and dirty fix. Please review and let me know if there are any questions/concerns/oversights. 