### PR TITLE
Initial Scaffolding of Mark Procedures for the Mark and Sweep Algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCE_FILES
         src/shaka_scheme/system/base/Character.cpp
         src/shaka_scheme/system/base/Vector.cpp
         src/shaka_scheme/system/gc/init_gc.cpp
+        src/shaka_scheme/system/gc/mark_procedures.cpp
         )
 
 add_library(${SHAKA_SCHEME_LIBRARY_NAME} SHARED ${SOURCE_FILES})

--- a/src/shaka_scheme/system/gc/GCNode.cpp
+++ b/src/shaka_scheme/system/gc/GCNode.cpp
@@ -4,6 +4,7 @@
 
 #include "shaka_scheme/system/gc/GCNode.hpp"
 #include "shaka_scheme/system/gc/GCData.hpp"
+#include <algorithm>
 
 namespace shaka {
 
@@ -17,7 +18,19 @@ GCNode::GCNode(GCData * data) {
 
 GCNode::GCNode(const GCNode& other) : gc_data(other.gc_data) {}
 
+GCNode::GCNode(GCNode&& other) : gc_data(other.gc_data) {
+  other.gc_data = nullptr;
+}
+
 GCNode::~GCNode() {}
+
+void swap(GCNode& lhs, GCNode& rhs) {
+  std::swap(lhs.gc_data, rhs.gc_data);
+}
+
+GCNode& GCNode::operator=(GCNode other) {
+  swap(*this, other);
+}
 
 Data& GCNode::operator*() const {
   return this->gc_data->get_data();

--- a/src/shaka_scheme/system/gc/GCNode.hpp
+++ b/src/shaka_scheme/system/gc/GCNode.hpp
@@ -5,39 +5,45 @@
 #ifndef SHAKA_SCHEME_GCNODE_HPP
 #define SHAKA_SCHEME_GCNODE_HPP
 
+#include "mark_procedures.hpp"
 
 namespace shaka {
-  class Data;
+class Data;
 
-    namespace gc {
-      class GCData;
+namespace gc {
+class GCData;
 /**
  * @brief Defines the type of GCNode, the object which will
  * wrap over GCData, providing a managed interface to Data
  */
-        class GCNode {
-        public:
+class GCNode {
+public:
 
-            GCNode();
-            GCNode(GCData *data);
-            GCNode(const GCNode& other);
-            ~GCNode();
+  GCNode();
+  GCNode(GCData * data);
+  GCNode(const GCNode& other);
+  GCNode(GCNode&& other);
+  ~GCNode();
 
-            Data &operator*() const;
-            Data *operator->() const;
+  Data& operator*() const;
+  Data * operator->() const;
 
-            Data *get() const;
-            operator bool() const;
+  Data * get() const;
+  operator bool() const;
 
-            friend bool operator==(const GCNode& lhs, const GCNode& rhs);
-            friend bool operator!=(const GCNode& lhs, const GCNode& rhs);
+  GCNode& operator=(GCNode other);
 
-        private:
-            GCData *gc_data;
-        };
+  friend bool operator==(const GCNode& lhs, const GCNode& rhs);
+  friend bool operator!=(const GCNode& lhs, const GCNode& rhs);
 
+  friend void mark_node(const GCNode& node);
+  friend void swap(GCNode& lhs, GCNode& rhs);
 
-    } // namespace gc
+private:
+  GCData * gc_data;
+};
+
+} // namespace gc
 } // namespace shaka
 
 #endif //SHAKA_SCHEME_GCNODE_HPP

--- a/src/shaka_scheme/system/gc/mark_procedures.cpp
+++ b/src/shaka_scheme/system/gc/mark_procedures.cpp
@@ -49,9 +49,15 @@ void mark_node(const GCNode& node) {
   case shaka::Data::Type::CLOSURE: {
     // If the argument is a closure, mark its environment, frame, and expression
     Closure c = node->get<Closure>();
-    mark_call_frame(*c.get_call_frame());
-    mark_environment(*c.get_environment());
-    mark_expression(c.get_function_body());
+    if (c.get_call_frame() != nullptr) {
+      mark_call_frame(*c.get_call_frame());
+    }
+    if (c.get_environment() != nullptr) {
+      mark_environment(*c.get_environment());
+    }
+    if (c.get_function_body() != nullptr) {
+      mark_expression(c.get_function_body());
+    }
     break;
   }
   case shaka::Data::Type::CALL_FRAME: {

--- a/src/shaka_scheme/system/gc/mark_procedures.cpp
+++ b/src/shaka_scheme/system/gc/mark_procedures.cpp
@@ -58,7 +58,7 @@ void mark_node(const GCNode& node) {
     // If the argument is a call frame, mark its contents
     mark_call_frame(node->get<CallFrame>());
     break;
-  }q
+  }
   default:
     break;
 

--- a/src/shaka_scheme/system/gc/mark_procedures.cpp
+++ b/src/shaka_scheme/system/gc/mark_procedures.cpp
@@ -8,19 +8,19 @@
 namespace shaka {
 namespace gc {
 
-static void mark_accumulator(Accumulator a) {
+void mark_accumulator(const Accumulator& a) {
 }
 
-static void mark_expression(Expression e) {
+void mark_expression(const Expression& e) {
 }
 
-static void mark_environment(Environment env) {
+void mark_environment(const Environment& env) {
 }
 
-static void mark_call_frame(CallFrame f) {
+void mark_call_frame(const CallFrame& f) {
 }
 
-static void mark_value_rib(ValueRib vr) {
+void mark_value_rib(const ValueRib& vr) {
 }
 
 void mark(const HeapVirtualMachine& hvm) {

--- a/src/shaka_scheme/system/gc/mark_procedures.cpp
+++ b/src/shaka_scheme/system/gc/mark_procedures.cpp
@@ -1,0 +1,76 @@
+//
+// Created by mortrax on 4/16/18.
+//
+#include "shaka_scheme/system/gc/GCNode.hpp"
+#include "shaka_scheme/system/vm/HeapVirtualMachine.hpp"
+#include "shaka_scheme/system/gc/GCData.hpp"
+
+namespace shaka {
+namespace gc {
+
+static void mark_accumulator(Accumulator a) {
+}
+
+static void mark_expression(Expression e) {
+}
+
+static void mark_environment(Environment env) {
+}
+
+static void mark_call_frame(CallFrame f) {
+}
+
+static void mark_value_rib(ValueRib vr) {
+}
+
+void mark(const HeapVirtualMachine& hvm) {
+  mark_accumulator(hvm.get_accumulator());
+  mark_expression(hvm.get_expression());
+  mark_environment(*hvm.get_environment());
+  mark_call_frame(*hvm.get_call_frame());
+  mark_value_rib(hvm.get_value_rib());
+}
+
+void mark_node(const GCNode& node) {
+
+  // Check for cycles
+  if (node.gc_data->is_marked()) {
+    return;
+  }
+
+  node.gc_data->mark();
+  switch(node->get_type()) {
+  case shaka::Data::Type::DATA_PAIR: {
+    // If the argument is a pair, mark its car and cdr
+    mark_node(node->get<DataPair>().car());
+    mark_node(node->get<DataPair>().cdr());
+    break;
+  }
+  case shaka::Data::Type::CLOSURE: {
+    // If the argument is a closure, mark its environment, frame, and expression
+    Closure c = node->get<Closure>();
+    mark_call_frame(*c.get_call_frame());
+    mark_environment(*c.get_environment());
+    mark_expression(c.get_function_body());
+    break;
+  }
+  case shaka::Data::Type::CALL_FRAME: {
+    // If the argument is a call frame, mark its contents
+    mark_call_frame(node->get<CallFrame>());
+    break;
+  }q
+  default:
+    break;
+
+  /*
+   * The following two cases will be added when the respective classes
+   * have been rolled into the Data variant class
+   * case shaka::Data::Type::VECTOR
+   * case shaka::Data::Type::BYTE_VECTOR
+   */
+  }
+}
+
+}
+}
+

--- a/src/shaka_scheme/system/gc/mark_procedures.hpp
+++ b/src/shaka_scheme/system/gc/mark_procedures.hpp
@@ -1,0 +1,23 @@
+//
+// Created by mortrax on 4/16/18.
+//
+
+#ifndef SHAKA_SCHEME_MARK_PROCEDURES_HPP
+#define SHAKA_SCHEME_MARK_PROCEDURES_HPP
+
+namespace shaka {
+
+class HeapVirtualMachine;
+
+namespace gc {
+
+class GCNode;
+
+
+extern void mark(const HeapVirtualMachine& hvm);
+extern void mark_node(const GCNode& node);
+
+}
+}
+
+#endif //SHAKA_SCHEME_MARK_PROCEDURES_HPP

--- a/src/shaka_scheme/system/gc/mark_procedures.hpp
+++ b/src/shaka_scheme/system/gc/mark_procedures.hpp
@@ -4,18 +4,31 @@
 
 #ifndef SHAKA_SCHEME_MARK_PROCEDURES_HPP
 #define SHAKA_SCHEME_MARK_PROCEDURES_HPP
+#include <deque>
 
 namespace shaka {
 
 class HeapVirtualMachine;
+class Environment;
+class CallFrame;
 
 namespace gc {
 
 class GCNode;
 
+using NodePtr = GCNode;
+using Accumulator = NodePtr;
+using Expression = NodePtr;
+using ValueRib = std::deque<NodePtr>;
 
 extern void mark(const HeapVirtualMachine& hvm);
 extern void mark_node(const GCNode& node);
+extern void mark_accumulator(const Accumulator& acc);
+extern void mark_environment(const Environment& env);
+extern void mark_expression(const Expression& e);
+extern void mark_call_frame(const CallFrame& f);
+extern void mark_value_rib(const ValueRib& vr);
+
 
 }
 }

--- a/tst/shaka_scheme/system/gc/CMakeLists.txt
+++ b/tst/shaka_scheme/system/gc/CMakeLists.txt
@@ -7,3 +7,5 @@ macro_shaka_scheme_test(unit-GCList)
 macro_shaka_scheme_test(unit-GC)
 
 macro_shaka_scheme_test(unit-GCInit)
+
+macro_shaka_scheme_test(unit-GCMark)

--- a/tst/shaka_scheme/system/gc/unit-GCMark.cpp
+++ b/tst/shaka_scheme/system/gc/unit-GCMark.cpp
@@ -1,0 +1,51 @@
+//
+// Created by mortrax on 4/16/18.
+//
+
+#include <gmock/gmock.h>
+#include "shaka_scheme/system/gc/GC.hpp"
+#include "shaka_scheme/system/gc/init_gc.hpp"
+
+/**
+ * @Test: mark_node() functionality on a DataPair
+ */
+TEST(GCMarkUnitTest, mark_node_pair_structure) {
+
+  // Given: You have constructed a GC and bound it to create_node
+
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
+
+  // Given: You have constructed a complex pair data structure
+
+  shaka::NodePtr sp1_car = shaka::create_node(shaka::Number(5));
+  shaka::NodePtr sp1_cdr = shaka::create_node(shaka::Number(4));
+
+  shaka::NodePtr sub_pair1 = shaka::create_node(shaka::DataPair(sp1_car,
+                                                                sp1_cdr));
+
+  shaka::NodePtr sp2_car = shaka::create_node(shaka::Symbol("a"));
+  shaka::NodePtr sp2_cdr = shaka::create_node(shaka::Symbol("b"));
+
+  shaka::NodePtr sub_pair2 = shaka::create_node(shaka::DataPair(sp2_car,
+  sp2_cdr));
+
+  shaka::NodePtr pair = shaka::create_node(shaka::DataPair(sub_pair1,
+                                                           sub_pair2));
+
+  // Then: The number of objects in the GC's managed memory is 27 due to
+  // calls to copy constructors
+
+  ASSERT_EQ(garbage_collector.get_size(), 27);
+
+  // When: You initiate a mark starting at pair, and then run a sweep
+
+  shaka::gc::mark_node(pair);
+  garbage_collector.sweep();
+
+  // Then: The number of objects in the GC's managed memeory is now 7
+  // reflecting the 7 explicit calls to create_node() made in this test
+
+  ASSERT_EQ(garbage_collector.get_size(), 7);
+
+}

--- a/tst/shaka_scheme/system/gc/unit-GCMark.cpp
+++ b/tst/shaka_scheme/system/gc/unit-GCMark.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gmock/gmock.h>
+#include <iostream>
 #include "shaka_scheme/system/gc/GC.hpp"
 #include "shaka_scheme/system/gc/init_gc.hpp"
 
@@ -47,5 +48,46 @@ TEST(GCMarkUnitTest, mark_node_pair_structure) {
   // reflecting the 7 explicit calls to create_node() made in this test
 
   ASSERT_EQ(garbage_collector.get_size(), 7);
+
+}
+
+/**
+ * @Test: mark_node() functionality on a DataPair with cyclic reference
+ */
+
+TEST(GCMarkUnitTest, mark_node_cyclic_pair_structure) {
+
+  // Given: You have constructed a GC and bound it to create_node
+  shaka::gc::GC garbage_collector;
+
+  shaka::gc::init_create_node(garbage_collector);
+
+  // Given: You have constructed a cyclic pair structure
+
+  shaka::NodePtr p1_car = shaka::create_node(shaka::Number(1));
+
+  shaka::NodePtr p1 = shaka::create_node(shaka::DataPair(p1_car));
+
+  shaka::NodePtr p2_car = shaka::create_node(shaka::Number(2));
+
+  shaka::NodePtr p2 = shaka::create_node(shaka::DataPair(p2_car));
+
+  p1->get<shaka::DataPair>().set_cdr(p2);
+  p2->get<shaka::DataPair>().set_cdr(p1);
+
+  // Then: The number of objects in the GC's managed memory is now 14,
+  // due to multiple copy constructor calls behind the scenes
+
+  ASSERT_EQ(garbage_collector.get_size(), 14);
+
+  // When: You initiate a mark() starting at p1, followed by a sweep()
+
+  mark_node(p1);
+  garbage_collector.sweep();
+
+  // Then: The number of objects in the GC's managed memory is now 4,
+  // reflecting the explicit calls to create_node made in this test
+
+  ASSERT_EQ(garbage_collector.get_size(), 4);
 
 }


### PR DESCRIPTION
Hello All,

This Pull Request sets into place the initial scaffolding of the suite of mark procedures that will comprise the overall mark algorithm used by the Garbage Collector system to perform mark and sweep. Most of the methods are void stubs, save for the `mark_node(const GCNode& node)` procedure, for which I have partially implemented and tested its functionality. The `mark_node()` procedure can already handle the proper marking of complex `DataPair` structures, including cyclic ones, and when used in unison with the `gc::GC::sweep()` method, is able to properly reclaim any unused memory in the system.

 You will notice in `unit-GCMark.cpp`, that prior to performing mark and sweep the number of allocated objects far outweighs the number of explicit calls made to `create_node()` in each of the test cases. However, once a mark/sweep cycle has been performed, the number of allocated objects in the `GC`'s managed memory is exactly the number of explicit calls made to `create_node()`, which is good. 

The excessive allocations are due to copy constructor invocations that are happening behind the scenes, I believe due to the handling of a `shaka::DataPair()` parameter being passed into the call to `create_node()`. Where the copy constructor calls are actually happening is difficult for me to determine at a cursory glance, and will likely require in-depth tracing to reveal. 

That being said, it appears that by doing mark and sweep, we are able to free all of the garbage memory generated by calls to `create_node()` that are internal to the copy constructor of `class DataPair`. Please review this PR and let me know if you feel there is anything that I have missed. The rest of the work of the core systems team over the coming week will be to fill in the body of the stub procedures and incrementally iterate on their functionality while writing test cases to verify them.

Cheers,

Troy