### PR TITLE
Fixed bug in GCNode assignment operator

### DIFF
--- a/src/shaka_scheme/system/gc/GCNode.cpp
+++ b/src/shaka_scheme/system/gc/GCNode.cpp
@@ -30,6 +30,7 @@ void swap(GCNode& lhs, GCNode& rhs) {
 
 GCNode& GCNode::operator=(GCNode other) {
   swap(*this, other);
+  return *this;
 }
 
 Data& GCNode::operator*() const {

--- a/tst/shaka_scheme/system/gc/unit-GCNode.cpp
+++ b/tst/shaka_scheme/system/gc/unit-GCNode.cpp
@@ -74,3 +74,33 @@ TEST (GCNodeUnitTest, test_get_method) {
 
   ASSERT_TRUE(num1.get() == env->get_value(shaka::Symbol("num1")).get());
 }
+
+/**
+ * @Test: Test assignment operator of GCNode
+ */
+TEST (GCNodeUnitTest, test_assignment_operator) {
+  // Given: You have created a garbage collector object
+
+  shaka::gc::GC garbage_collector;
+
+  // Given: You have bound create_node() to this garbage collector
+
+  shaka::gc::init_create_node(garbage_collector);
+
+  // Given: You have created a GCNode using create_node();
+
+  shaka::NodePtr node = shaka::create_node(shaka::Data(shaka::Number(5)));
+
+  // When: You assign this node to a separate NodePtr reference
+
+  shaka::NodePtr copy_node = node;
+
+  // Then: The contents of the two NodePtrs should be the same
+
+  ASSERT_EQ(node->get<shaka::Number>(), copy_node->get<shaka::Number>());
+
+  // Then: The two NodePtrs should point to the same Data object
+
+  ASSERT_EQ(node.get(), copy_node.get());
+
+}


### PR DESCRIPTION
Resolves #76 

Fixed the missing `return *this` in the assignment operator of GCNode and included a unit test case in `unit-GCNode`verifying the functionality of the assignment operator.