### PR TITLE
Completion of Garbage Collector Mark Routines

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
 #include "shaka_scheme/system/gc/GC.hpp"
 #include "shaka_scheme/system/gc/init_gc.hpp"
 #include "shaka_scheme/system/base/DataPair.hpp"
+#include "shaka_scheme/system/gc/mark_procedures.hpp"
 
 int main() {
   using namespace shaka;
@@ -195,6 +196,9 @@ int main() {
       } while (shaka::core::car(hvm.get_expression())->get<shaka::Symbol>() !=
           shaka::Symbol("halt"));
       std::cout << *hvm.get_accumulator() << std::endl;
+      shaka::gc::mark(hvm);
+      mark_node(halt_instruction);
+      garbage_collector.sweep();
     } catch (shaka::InvalidInputException e) {
       std::cerr << "InvalidInputException: " << e.what() << std::endl;
     } catch (shaka::TypeException e) {

--- a/src/shaka_scheme/system/vm/CallFrame.cpp
+++ b/src/shaka_scheme/system/vm/CallFrame.cpp
@@ -25,19 +25,19 @@ shaka::CallFrame::CallFrame() {
 }
 
 
-shaka::Expression shaka::CallFrame::get_next_expression() {
+shaka::Expression shaka::CallFrame::get_next_expression() const {
   return return_expression;
 }
 
-shaka::EnvPtr shaka::CallFrame::get_environment_pointer() {
+shaka::EnvPtr shaka::CallFrame::get_environment_pointer() const {
   return env;
 }
 
-shaka::ValueRib shaka::CallFrame::get_value_rib() {
+shaka::ValueRib shaka::CallFrame::get_value_rib() const {
   return value_rib;
 }
 
-shaka::FramePtr shaka::CallFrame::get_next_frame() {
+shaka::FramePtr shaka::CallFrame::get_next_frame() const {
   return next_frame;
 }
 

--- a/src/shaka_scheme/system/vm/CallFrame.hpp
+++ b/src/shaka_scheme/system/vm/CallFrame.hpp
@@ -49,27 +49,27 @@ public:
    * @brief Getter method for next_expression (return address)
    * @return The contents of the next expression field
    */
-  Expression get_next_expression();
+  Expression get_next_expression() const;
 
 
   /**
    * @brief Getter method for the active environment
    * @return The contents of the environment field (EnvPtr)
    */
-  EnvPtr get_environment_pointer();
+  EnvPtr get_environment_pointer() const;
 
   /**
    * @brief Getter method for the value rib
    * @return The vector of the arugments evaluated thus far in the CallFrame
    */
-  ValueRib get_value_rib();
+  ValueRib get_value_rib() const;
 
 
   /**
    * @brief Getter method for the pointer to the ControlStack
    * @return The contents of the next_frame field (rest of ControlStack)
    */
-  FramePtr get_next_frame();
+  FramePtr get_next_frame() const;
 
   /**
    * @brief Setter method for the expression field (return address)

--- a/tst/shaka_scheme/system/gc/unit-GCMark.cpp
+++ b/tst/shaka_scheme/system/gc/unit-GCMark.cpp
@@ -147,3 +147,35 @@ TEST(GCMarkUnitTest, mark_closure_object) {
   ASSERT_EQ(closure_node->get<shaka::Closure>().get_variable_list(),
             c.get_variable_list());
 }
+
+/**
+ * @Test: mark_node() on a shaka::Vector
+ */
+TEST(GCMarkUnitTest, mark_vector_object) {
+  //Given: You have constructed a GC object and bound it to create_node()
+  shaka::gc::GC garbage_collector;
+  shaka::gc::init_create_node(garbage_collector);
+
+  // Given: You have constructed a shaka::Vector as follows
+
+  shaka::NodePtr node1 = shaka::create_node(shaka::Number(1));
+  shaka::NodePtr node2 = shaka::create_node(shaka::Number(2));
+  shaka::NodePtr node3 = shaka::create_node(shaka::DataPair(node1, node2));
+
+  shaka::Vector v{node1, node2, node3};
+
+  shaka::NodePtr vector_node = shaka::create_node(v);
+
+  // When: You call mark on vector_node and sweep on the GC
+  shaka::gc::mark_node(vector_node);
+  garbage_collector.sweep();
+
+  // Then: The number of objects in GC memory is 6
+
+  ASSERT_EQ(garbage_collector.get_size(), 6);
+
+  // Then: The number of objects in vector_node is 3
+
+  ASSERT_EQ(vector_node->get<shaka::Vector>().length(), 3);
+
+}


### PR DESCRIPTION
Hello All,

The full suite of mark routines comprising the functionality of the Garbage Collector's mark/sweep is now complete. Unit tests have been included to verify the functionality of marking `shaka::Vector` and `shaka::Closure` objects. While `mark_call_frame()` was not explicitly tested, it's functionality has been confirmed via the execution of the following code in the main REPL executable with mark/sweep running in the background:

`(define (f proc) (f 'b) 'a)`
`=> <#procedure>`
`(define (id x) x)`
`=> <#procedure>`
`(f id) => a`
`(call/cc f) => b`

That last line of `(call/cc f)`, while seemingly innocuous at first glance, implicitly involves an indecent amount of complex processes and register manipulations happening behind the scenes within the Virtual Machine. First, a continuation instance of a `Closure` object is created and passed as the single argument to the `Closure` object bound to `f` in the VM's environment. Inside of the body of `f`, this continuation is called on the `Symbol` `b`, which results in the evaluation of the body of the continuation, leading to a jump through the stack of `CallFrames`, and various other complex register reassignments. The integrity of the entire REPL system, including `Parser`, `MacroContext`, `Compiler`, and `HeapVirtualMachine` remained well intact after numerous other lines of code were executed, each followed by immediate calls to `mark()` and `sweep()`. I would say that barring any insidious and/or highly cryptic bugs, this serves to confirm the functionality of the Garbage Collector as it exists in its current form. Please review this Pull Request at your earliest convenience and let me know if you have any questions/concerns about the code presented herein.

Cheers,
Troy